### PR TITLE
Trust boot assets used in the current boot

### DIFF
--- a/cmd/nullbootctl/main.go
+++ b/cmd/nullbootctl/main.go
@@ -33,6 +33,11 @@ func main() {
 		}
 	}
 
+	if err := efibootmgr.TrustCurrentBoot(assets, esp); err != nil {
+		log.Println("cannot trust boot assets used for current boot:", err)
+		os.Exit(1)
+	}
+
 	km, err := efibootmgr.NewKernelManager(esp, kernelSourceDir, vendor)
 	if err != nil {
 		log.Print(err)

--- a/efibootmgr/hashed_file.go
+++ b/efibootmgr/hashed_file.go
@@ -1,0 +1,155 @@
+// This file is part of nullboot
+// Copyright 2021 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+package efibootmgr
+
+import (
+	"bytes"
+	"crypto"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// hashedFile wraps a file handle and builds a list of per-block hashes for
+// each block of data read from the file.
+//
+// During read operations, hashes are computed on a block-by-block basis. If a
+// block's hash hasn't previously been computed, then it is recorded. If it
+// has previously been computed, then the hash is compared against the previously
+// recorded one and an error returns if it is different.
+//
+// During close, any previously unread blocks are read in order to compute their
+// hashes. A notify function is then called with the list of hashes for external
+// code to verify. This allows verification to be performed without the risk of
+// TOCTOU type bugs and without having to read and keep the entire file in
+// memory whilst it is being used.
+type hashedFile struct {
+	file File
+	sz   int64
+
+	alg              crypto.Hash
+	closeNotify      func([][]byte)
+	leafHashes       [][]byte
+	cachedBlockIndex int64
+	cachedBlock      []byte
+}
+
+// newHashedFile creates a new hashedFile from the supplied file handle. When the
+// file is closed, the supplied closeNotify callback will be called with a list
+// of per-block hashes from the file.
+func newHashedFile(f File, alg crypto.Hash, closeNotify func([][]byte)) (*hashedFile, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return &hashedFile{
+		file:             f,
+		sz:               info.Size(),
+		alg:              alg,
+		closeNotify:      closeNotify,
+		leafHashes:       make([][]byte, (info.Size()+(hashBlockSize-1))/hashBlockSize),
+		cachedBlockIndex: -1}, nil
+}
+
+func (f *hashedFile) readAndCacheBlock(i int64) error {
+	if i == f.cachedBlockIndex {
+		// Reading from the cached block
+		return nil
+	}
+
+	if i >= int64(len(f.leafHashes)) {
+		// Huh, out of range
+		return io.EOF
+	}
+
+	// Read the whole block
+	r := io.NewSectionReader(f.file, i*hashBlockSize, hashBlockSize)
+
+	var block [hashBlockSize]byte
+	n, err := io.ReadFull(r, block[:])
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+		// Handle io.ErrUnexpectedEOF later.
+		return err
+	}
+
+	// Cache this block to speed up small reads
+	f.cachedBlockIndex = i
+	f.cachedBlock = block[:n]
+
+	// Hash the block
+	h := f.alg.New()
+	h.Write(block[:])
+
+	if len(f.leafHashes[i]) == 0 {
+		// This is the first time we read this block.
+		f.leafHashes[i] = h.Sum(nil)
+	} else if !bytes.Equal(h.Sum(nil), f.leafHashes[i]) {
+		// We've read this block before, and it has changed.
+		return fmt.Errorf("hash check fail for block %d", i)
+	}
+
+	return err
+}
+
+func (f *hashedFile) ReadAt(p []byte, off int64) (n int, err error) {
+	// Calculate the starting block and number of blocks.
+	start := ((off + hashBlockSize) / hashBlockSize) - 1
+	end := ((off + int64(len(p)) + hashBlockSize) / hashBlockSize)
+	num := end - start
+
+	// Read and hash each block.
+	for i := start; i < start+num; i++ {
+		if err := f.readAndCacheBlock(i); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+			break
+		}
+
+		data := f.cachedBlock
+		if n == 0 {
+			off0 := off - (start * hashBlockSize)
+			data = data[off0:]
+		}
+		sz := len(p) - n
+		if sz < len(data) {
+			data = data[:sz]
+		}
+
+		copy(p[n:], data)
+		n += len(data)
+
+		if err != nil {
+			break
+		}
+	}
+
+	if n == 0 {
+		return 0, io.EOF
+	}
+	return n, nil
+}
+
+func (f *hashedFile) Close() error {
+	// Loop over missing leaf hashes.
+	for i, d := range f.leafHashes {
+		if len(d) > 0 {
+			continue
+		}
+
+		// Hash missing block.
+		if err := f.readAndCacheBlock(int64(i)); err != nil {
+			break
+		}
+	}
+
+	if f.closeNotify != nil {
+		f.closeNotify(f.leafHashes)
+	}
+
+	return f.file.Close()
+}
+
+func (f *hashedFile) Size() int64 {
+	return f.sz
+}

--- a/efibootmgr/hashed_file_test.go
+++ b/efibootmgr/hashed_file_test.go
@@ -1,0 +1,114 @@
+// This file is part of nullboot
+// Copyright 2021 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+package efibootmgr
+
+import (
+	"crypto"
+	"errors"
+	"io"
+
+	"gopkg.in/check.v1"
+)
+
+type hashedFileSuite struct {
+	mapFsMixin
+}
+
+var _ = check.Suite(&hashedFileSuite{})
+
+type testHashedFileReadBlock struct {
+	off int64
+	sz  int64
+	n   int64
+}
+
+func (s *hashedFileSuite) testHashedFile(c *check.C, path string, blocks []testHashedFileReadBlock) {
+	f, err := appFs.Open(path)
+	c.Assert(err, check.IsNil)
+	defer f.Close()
+
+	var leafHashes [][]byte
+
+	for {
+		var data [hashBlockSize]byte
+		n, err := f.Read(data[:])
+		if n > 0 {
+			h := crypto.SHA256.New()
+			h.Write(data[:])
+			leafHashes = append(leafHashes, h.Sum(nil))
+		}
+		if err != nil {
+			break
+		}
+	}
+	h := crypto.SHA256.New()
+	for _, leaf := range leafHashes {
+		h.Write(leaf)
+	}
+	expectedHash := h.Sum(nil)
+	leafHashes = nil
+
+	hf, err := newHashedFile(f, crypto.SHA256, func(hashes [][]byte) {
+		leafHashes = hashes
+	})
+	c.Assert(err, check.IsNil)
+
+	for _, block := range blocks {
+		total := block.sz * block.n
+
+		expected := make([]byte, total)
+		data := make([]byte, total)
+
+		for i := int64(0); i < total; {
+			n, err := f.ReadAt(expected[i:i+block.sz], i+block.off)
+			if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) || int64(n) < block.sz {
+				break
+			}
+			c.Check(err, check.IsNil)
+			i += int64(n)
+		}
+
+		for i := int64(0); i < total; {
+			n, err := hf.ReadAt(data[i:i+block.sz], i+block.off)
+			if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) || int64(n) < block.sz {
+				break
+			}
+			c.Check(err, check.IsNil)
+			i += int64(n)
+		}
+
+		c.Check(data, check.DeepEquals, expected)
+	}
+
+	c.Check(hf.Close(), check.IsNil)
+
+	h = crypto.SHA256.New()
+	for _, leaf := range leafHashes {
+		h.Write(leaf)
+	}
+	c.Check(h.Sum(nil), check.DeepEquals, expectedHash)
+}
+
+func (s *hashedFileSuite) TestHashedFileReadFullSmallReads(c *check.C) {
+	s.writeFile(c, "/foo", 0, 199, 3500)
+	s.testHashedFile(c, "/foo", []testHashedFileReadBlock{
+		{off: 0, sz: 10, n: 69650},
+	})
+}
+
+func (s *hashedFileSuite) TestHashedFileReadFullLargeReads(c *check.C) {
+	s.writeFile(c, "/foo", 0, 199, 3500)
+	s.testHashedFile(c, "/foo", []testHashedFileReadBlock{
+		{off: 0, sz: 69650, n: 10},
+	})
+}
+
+func (s *hashedFileSuite) TestHashedFileReadSparse(c *check.C) {
+	s.writeFile(c, "/foo", 0, 199, 3500)
+	s.testHashedFile(c, "/foo", []testHashedFileReadBlock{
+		{off: 500, sz: 10, n: 100},
+		{off: 20000, sz: 500, n: 20},
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/canonical/go-efilib v0.2.0
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 // indirect
 	github.com/canonical/go-tpm2 v0.1.0
-	github.com/canonical/tcglog-parser v0.0.0-20210824131805-69fa1e9f0ad2 // indirect
+	github.com/canonical/tcglog-parser v0.0.0-20210824131805-69fa1e9f0ad2
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d
 	github.com/snapcore/secboot v0.0.0-20211029143450-8cdfc8e774d0


### PR DESCRIPTION
The resealing code computes PCR digests from assets unpacked to the ESP,
which depends on a list of hashes of boot assets that have previously
been established as trusted by nullboot. This list of hashes doesn't
exist on first boot though - the trust here is established by the
provisioning of the image, which trusts the initial boot assets. To handle
this case, always trust the boot assets used in the current boot,
determined by inspecting the TCG log.