### PR TITLE
Add a -image-build flag

### DIFF
--- a/cmd/nullbootctl/main.go
+++ b/cmd/nullbootctl/main.go
@@ -9,7 +9,12 @@ import "flag"
 import "log"
 import "os"
 
+var noTPM = flag.Bool("no-tpm", false, "Do not do any resealing with the TPM")
+var noEfivars = flag.Bool("no-efivars", false, "Do not use or update the EFI variables")
+
 func main() {
+	var assets *efibootmgr.TrustedAssets
+	var err error
 	flag.Parse()
 
 	const (
@@ -20,39 +25,53 @@ func main() {
 	)
 
 	// FIXME: Let's actually add some arg parsing and stuff?
-	assets, err := efibootmgr.ReadTrustedAssets()
-	if err != nil {
-		log.Println("cannot read trusted asset hashes:", err)
-		os.Exit(1)
-	}
+	if !*noTPM {
+		assets, err = efibootmgr.ReadTrustedAssets()
+		if err != nil {
+			log.Println("cannot read trusted asset hashes:", err)
+			os.Exit(1)
+		}
 
-	for _, p := range []string{shimSourceDir, kernelSourceDir} {
-		if err := assets.TrustNewFromDir(p); err != nil {
-			log.Println("cannot add new assets from", p, ":", err)
+		for _, p := range []string{shimSourceDir, kernelSourceDir} {
+			if err := assets.TrustNewFromDir(p); err != nil {
+				log.Println("cannot add new assets from", p, ":", err)
+				os.Exit(1)
+			}
+		}
+
+		if err := efibootmgr.TrustCurrentBoot(assets, esp); err != nil {
+			log.Println("cannot trust boot assets used for current boot:", err)
 			os.Exit(1)
 		}
 	}
 
-	if err := efibootmgr.TrustCurrentBoot(assets, esp); err != nil {
-		log.Println("cannot trust boot assets used for current boot:", err)
-		os.Exit(1)
+	var maybeBm *efibootmgr.BootManager
+	if !*noEfivars {
+		if bm, err := efibootmgr.NewBootManagerFromSystem(); err != nil {
+			log.Println("cannot load efi boot variables:", err)
+			os.Exit(1)
+		} else {
+			maybeBm = &bm
+		}
 	}
 
-	km, err := efibootmgr.NewKernelManager(esp, kernelSourceDir, vendor)
+	km, err := efibootmgr.NewKernelManager(esp, kernelSourceDir, vendor, maybeBm)
 	if err != nil {
 		log.Print(err)
 		os.Exit(1)
 	}
 
-	if err := assets.Save(); err != nil {
-		log.Println("cannot update list of trusted boot assets:", err)
-		os.Exit(1)
-	}
+	if assets != nil {
+		if err := assets.Save(); err != nil {
+			log.Println("cannot update list of trusted boot assets:", err)
+			os.Exit(1)
+		}
 
-	// Initial reseal against new assets
-	if err := efibootmgr.ResealKey(assets, km, esp, shimSourceDir, vendor); err != nil {
-		log.Println("initial reseal failed:", err)
-		os.Exit(1)
+		// Initial reseal against new assets
+		if err := efibootmgr.ResealKey(assets, km, esp, shimSourceDir, vendor); err != nil {
+			log.Println("initial reseal failed:", err)
+			os.Exit(1)
+		}
 	}
 
 	// Install the shim
@@ -84,15 +103,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	assets.RemoveObsolete()
-	if err := assets.Save(); err != nil {
-		log.Println("cannot update list of trusted boot assets:", err)
-		os.Exit(1)
-	}
+	if assets != nil {
+		assets.RemoveObsolete()
+		if err := assets.Save(); err != nil {
+			log.Println("cannot update list of trusted boot assets:", err)
+			os.Exit(1)
+		}
 
-	// Final reseal to remove obsolete assets from profile
-	if err := efibootmgr.ResealKey(assets, km, esp, shimSourceDir, vendor); err != nil {
-		log.Println("final reseal failed:", err)
-		os.Exit(1)
+		// Final reseal to remove obsolete assets from profile
+		if err := efibootmgr.ResealKey(assets, km, esp, shimSourceDir, vendor); err != nil {
+			log.Println("final reseal failed:", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/efibootmgr/kernel_test.go
+++ b/efibootmgr/kernel_test.go
@@ -57,7 +57,7 @@ func TestKernelManagerNewAndInstallKernels(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu")
+	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu", &bm)
 	if err != nil {
 		t.Fatalf("Could not create kernel manager: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestKernelManager_noCmdLine(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu")
+	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu", &bm)
 	if err := km.InstallKernels(); err != nil {
 		t.Errorf("Could not install kernels: %v", err)
 	}
@@ -200,8 +200,11 @@ func TestKernelManagerRemoveObsoleteKernels(t *testing.T) {
 		},
 	}
 	appEFIVars = &mockvars
-
-	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu")
+	bm, err := NewBootManagerFromSystem()
+	if err != nil {
+		t.Fatalf("Could not create boot manager: %v", err)
+	}
+	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu", &bm)
 	if err != nil {
 		t.Fatalf("Could not create kernel manager: %v", err)
 	}

--- a/efibootmgr/reseal_test.go
+++ b/efibootmgr/reseal_test.go
@@ -317,7 +317,9 @@ func (s *resealSuite) testResealKey(c *check.C, data *testResealKeyData) {
 	c.Check(assets.TrustNewFromDir("/usr/lib/nullboot/shim"), check.IsNil)
 	c.Check(assets.TrustNewFromDir("/usr/lib/linux"), check.IsNil)
 
-	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu")
+	bm, err := NewBootManagerFromSystem()
+	c.Assert(err, check.IsNil)
+	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu", &bm)
 	c.Assert(err, check.IsNil)
 
 	c.Check(ResealKey(assets, km, "/boot/efi", "/usr/lib/nullboot/shim", "ubuntu"), check.IsNil)
@@ -701,7 +703,9 @@ func (s *resealSuite) testResealKeyUnhappy(c *check.C, data *testResealKeyUnhapp
 	c.Check(assets.TrustNewFromDir("/usr/lib/nullboot/shim"), check.IsNil)
 	c.Check(assets.TrustNewFromDir("/usr/lib/linux"), check.IsNil)
 
-	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu")
+	bm, err := NewBootManagerFromSystem()
+	c.Assert(err, check.IsNil)
+	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu", &bm)
 	c.Assert(err, check.IsNil)
 
 	return ResealKey(assets, km, "/boot/efi", "/usr/lib/nullboot/shim", "ubuntu")


### PR DESCRIPTION
The -image-build flag is used for initial setup of the bootloader
at image build time, it only updates the ESP but does not do any
of the resealing or EFI variable modification bits.