### PR TITLE
shim: fallback: Terminate optional data (kernel) with space

### DIFF
--- a/efibootmgr/kernel_test.go
+++ b/efibootmgr/kernel_test.go
@@ -95,8 +95,8 @@ func TestKernelManagerNewAndInstallKernels(t *testing.T) {
 		t.Fatalf("Could not read boot.csv: %v", err)
 	}
 
-	want := ("shim" + GetEfiArchitecture() + ".efi,Ubuntu with kernel 1.0-1-generic,\\kernel.efi-1.0-1-generic root=magic,Ubuntu entry for kernel 1.0-1-generic\n" +
-		"shim" + GetEfiArchitecture() + ".efi,Ubuntu with kernel 1.0-12-generic,\\kernel.efi-1.0-12-generic root=magic,Ubuntu entry for kernel 1.0-12-generic\n")
+	want := ("shim" + GetEfiArchitecture() + ".efi,Ubuntu with kernel 1.0-1-generic,\\kernel.efi-1.0-1-generic root=magic ,Ubuntu entry for kernel 1.0-1-generic\n" +
+		"shim" + GetEfiArchitecture() + ".efi,Ubuntu with kernel 1.0-12-generic,\\kernel.efi-1.0-12-generic root=magic ,Ubuntu entry for kernel 1.0-12-generic\n")
 	if want != string(data) {
 		t.Errorf("Boot entry mismatch:\nExpected:\n%v\nGot:\n%v", want, string(data))
 	}
@@ -160,8 +160,8 @@ func TestKernelManager_noCmdLine(t *testing.T) {
 		t.Fatalf("Could not read boot.csv: %v", err)
 	}
 
-	want := ("shim" + GetEfiArchitecture() + ".efi,Ubuntu with kernel 1.0-1-generic,\\kernel.efi-1.0-1-generic,Ubuntu entry for kernel 1.0-1-generic\n" +
-		"shim" + GetEfiArchitecture() + ".efi,Ubuntu with kernel 1.0-12-generic,\\kernel.efi-1.0-12-generic,Ubuntu entry for kernel 1.0-12-generic\n")
+	want := ("shim" + GetEfiArchitecture() + ".efi,Ubuntu with kernel 1.0-1-generic,\\kernel.efi-1.0-1-generic ,Ubuntu entry for kernel 1.0-1-generic\n" +
+		"shim" + GetEfiArchitecture() + ".efi,Ubuntu with kernel 1.0-12-generic,\\kernel.efi-1.0-12-generic ,Ubuntu entry for kernel 1.0-12-generic\n")
 	if want != string(data) {
 		t.Errorf("Boot entry mismatch:\nExpected:\n%v\nGot:\n%v", want, string(data))
 	}

--- a/efibootmgr/shim.go
+++ b/efibootmgr/shim.go
@@ -83,7 +83,13 @@ func WriteShimFallback(w io.Writer, entries []BootEntry) error {
 			return fmt.Errorf("entry '%s' contains ',' in one of the attributes, this is not supported", entry.Label)
 		}
 
-		_, err := fmt.Fprintf(w, "%s,%s,%s,%s\n", entry.Filename, entry.Label, entry.Options, entry.Description)
+		// We have an empty space after Options, because if there is no space in the options, shim
+		// does not seem to parse them at all.
+		var options = entry.Options
+		if options != "" {
+			options += " "
+		}
+		_, err := fmt.Fprintf(w, "%s,%s,%s,%s\n", entry.Filename, entry.Label, options, entry.Description)
 		if err != nil {
 			return fmt.Errorf("Could not write entry '%s' to file: %w", entry.Label, err)
 		}

--- a/efibootmgr/shim_test.go
+++ b/efibootmgr/shim_test.go
@@ -31,7 +31,7 @@ func TestWriteShimFallback(t *testing.T) {
 			{"shimx64.efi", "ubuntu", "", "This is the boot entry for ubuntu"},
 			{"shimx64.efi", "Linux-Firmware-Updater", "\\fwupdx64.efi", "This is the boot entry for Linux-Firmware-Updater"},
 		},
-			"shimx64.efi,Linux-Firmware-Updater,\\fwupdx64.efi,This is the boot entry for Linux-Firmware-Updater\n" +
+			"shimx64.efi,Linux-Firmware-Updater,\\fwupdx64.efi ,This is the boot entry for Linux-Firmware-Updater\n" +
 				"shimx64.efi,ubuntu,,This is the boot entry for ubuntu\n",
 		},
 	}


### PR DESCRIPTION
When writing the variable ourselves, we terminate the optional
data with a UCS 0 character, e.g. two bytes '\0\0'.

Fallback does not do that, and shim ends up ignoring the kernel
passed this way.

Adding a space also seems to work, so let's do this here.