### PR TITLE
Nullboot fallback mechanism

### DIFF
--- a/cmd/nullbootctl/main.go
+++ b/cmd/nullbootctl/main.go
@@ -10,8 +10,9 @@ import "log"
 import "os"
 
 var noTPM = flag.Bool("no-tpm", false, "Do not do any resealing with the TPM")
-var noEfivars = flag.Bool("no-efivars", false, "Do not use or update the EFI variables")
-var outputJSON = flag.String("output-json", "", "JSON file to write (also disables writing real EFI variables)")
+var noEfivars = flag.Bool("no-efivars", false, "Do not use or update the EFI variables. Disables kernel fallback mechanism")
+var outputJSON = flag.String("output-json", "", "JSON file to write. Disables writing real EFI variables and enablement of the kernel fallback mechanism")
+var noBootNext = flag.Bool("no-boot-next", false, "Disables use of BootNext. This flag must be disabled in order to upgrade to a new kernel version.")
 
 func main() {
 	var assets *efibootmgr.TrustedAssets
@@ -25,7 +26,7 @@ func main() {
 		vendor          = "ubuntu"
 	)
 
-	// FIXME: Let's actually add some arg parsing and stuff?
+	usingRealEFIVars := *outputJSON == "" && !*noEfivars
 	if !*noTPM {
 		assets, err = efibootmgr.ReadTrustedAssets()
 		if err != nil {
@@ -102,18 +103,50 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = km.CommitToBootLoader(); err != nil {
-		log.Print(err)
-		os.Exit(1)
+	// Determine if the fallback mechanism is required
+	isCurrentBootLatest := true
+	if usingRealEFIVars {
+		// Only set fallback if the latest kernel is not booted
+		isCurrentBootLatest, err = km.IsCurrentBootLatest()
+		if err != nil {
+			log.Printf("Unable to determine if the latest kernel is BootCurrent: %v", err)
+			os.Exit(1)
+		}
+		log.Println("BootCurrent is not the latest installed kernel entry")
 	}
-	// Cleanup old entries
-	if err = km.RemoveObsoleteKernels(); err != nil {
-		log.Print(err)
-		os.Exit(1)
-	}
-	if err = km.CommitToBootLoader(); err != nil {
-		log.Print(err)
-		os.Exit(1)
+
+	// If current boot is not latest, set latest to BootNext so it can
+	// attempt to boot on next reboot
+	//
+	// Else, the current kernel booted successfully and the EFI variables
+	// can be updated accordingly; notably, the BootCurrent will become
+	// BootOrder[0]
+	if !isCurrentBootLatest {
+		if !*noBootNext {
+			if err := km.SetLatestKernelToBootNext(); err != nil {
+				log.Printf("Unable to set kernel fallback for new kernel: %v", err)
+				os.Exit(1)
+			}
+			log.Println("Set kernel fallback mechanism for newly installed kernel")
+		}
+	} else {
+		if err = km.CommitToBootLoader(); err != nil {
+			log.Print(err)
+			os.Exit(1)
+		}
+		// Cleanup old entries
+		if err = km.RemoveObsoleteKernels(); err != nil {
+			log.Print(err)
+			os.Exit(1)
+		}
+		// This second call is intended to cleanup Boot variables that
+		// become obsolete after the first call. It is not explicitly
+		// tested, but I am not convinced that it is necessary. Regardless,
+		// I do not want to break anything since I am not 100% sure of this
+		if err = km.CommitToBootLoader(); err != nil {
+			log.Print(err)
+			os.Exit(1)
+		}
 	}
 
 	if assets != nil {
@@ -129,7 +162,6 @@ func main() {
 			os.Exit(1)
 		}
 	}
-
 	if jsonEfivars, ok := efivars.(*efibootmgr.MockEFIVariables); ok {
 		json, err := jsonEfivars.JSON()
 		if err != nil {

--- a/cmd/nullbootctl/main.go
+++ b/cmd/nullbootctl/main.go
@@ -96,6 +96,12 @@ func main() {
 		log.Print(err)
 		os.Exit(1)
 	}
+
+	if err = km.RegisterNewKernelEFIs(); err != nil {
+		log.Print(err)
+		os.Exit(1)
+	}
+
 	if err = km.CommitToBootLoader(); err != nil {
 		log.Print(err)
 		os.Exit(1)

--- a/efibootmgr/bootmgr.go
+++ b/efibootmgr/bootmgr.go
@@ -19,6 +19,9 @@ import (
 
 const (
 	maxBootEntries = 65535 // Maximum number of boot entries we can hold
+	bootCurrentStr = "BootCurrent"
+	bootNextStr    = "BootNext"
+	bootOrderStr   = "BootOrder"
 )
 const invalidBootNumber = -1
 const defaultBootVariableAttributes = efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess
@@ -89,31 +92,31 @@ func NewBootManagerForVariables(efivars EFIVariables) (BootManager, error) {
 		return BootManager{}, fmt.Errorf("Variables not supported")
 	}
 
-	if bootCurrentBytes, _, err := bm.efivars.GetVariable(efi.GlobalVariable, "BootCurrent"); err != nil {
+	if bootCurrentBytes, _, err := bm.efivars.GetVariable(efi.GlobalVariable, bootCurrentStr); err != nil {
 		switch bm.efivars.(type) {
 		// BootCurrent is a volatile entry that is created upon a
 		// successful boot into some boot entry. Since MockEFIVariables is
 		// not representing a live host, BootCurrent does not need to exist
 		case *MockEFIVariables:
-			log.Printf("Could not read BootCurrent variable, populating with default (%d), error was: %v\n", invalidBootNumber, err)
+			log.Printf("Could not read %s variable, populating with default (%d), error was: %v\n", bootCurrentStr, invalidBootNumber, err)
 			bm.bootCurrent = invalidBootNumber
 		default:
-			return BootManager{}, fmt.Errorf("could not read BootCurrent variable, error was: %w\n", err)
+			return BootManager{}, fmt.Errorf("could not read %s variable, error was: %w\n", bootCurrentStr, err)
 		}
 	} else {
 		bm.bootCurrent = int(binary.LittleEndian.Uint16(bootCurrentBytes[0:2]))
 	}
 
 	// It's possible that BootNext is active from user input or a previous iteration of nullboot
-	if bootNextBytes, _, err := bm.efivars.GetVariable(efi.GlobalVariable, "BootNext"); err != nil {
+	if bootNextBytes, _, err := bm.efivars.GetVariable(efi.GlobalVariable, bootNextStr); err != nil {
 		if len(bootNextBytes) != 0 {
 			bm.bootNext = int(binary.LittleEndian.Uint16(bootNextBytes[0:2]))
 		}
 	}
 
-	bootOrderBytes, bootOrderAttrs, err := bm.efivars.GetVariable(efi.GlobalVariable, "BootOrder")
+	bootOrderBytes, bootOrderAttrs, err := bm.efivars.GetVariable(efi.GlobalVariable, bootOrderStr)
 	if err != nil {
-		log.Println("Could not read BootOrder variable, populating with default, error was:", err)
+		log.Printf("Could not read %s variable, populating with default, error was: %v", bootOrderStr, err)
 		bootOrderBytes = nil
 		bootOrderAttrs = efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess
 	}
@@ -282,7 +285,7 @@ func (bm *BootManager) DeleteEntry(bootNum int) error {
 		log.Printf("the entry associated to BootCurrent (%s) has been deleted\n", toEFIBootEntryFormat(bootNum))
 	} else if bootNum == bm.bootNext {
 		log.Printf("the entry associated to BootNext (%s) has been deleted and un-set\n", toEFIBootEntryFormat(bootNum))
-		if err := DelVariable(bm.efivars, efi.GlobalVariable, "BootNext"); err != nil {
+		if err := DelVariable(bm.efivars, efi.GlobalVariable, bootNextStr); err != nil {
 			return err
 		}
 
@@ -331,7 +334,7 @@ func (bm *BootManager) PrependAndSetBootOrder(head []int) error {
 	}
 
 	// Set the boot order and update our cache
-	if err := bm.efivars.SetVariable(efi.GlobalVariable, "BootOrder", output, bm.bootOrderAttrs); err != nil {
+	if err := bm.efivars.SetVariable(efi.GlobalVariable, bootOrderStr, output, bm.bootOrderAttrs); err != nil {
 		return err
 	}
 
@@ -357,7 +360,7 @@ func (bm *BootManager) SetBootNext(bootNum int) error {
 		return fmt.Errorf("unable to find %s: %w", bootEntryName, err)
 	}
 	bootNumBytes := toEFIBootEntryBytes(bootNum)
-	if err := bm.efivars.SetVariable(efi.GlobalVariable, "BootNext", bootNumBytes, bm.bootOrderAttrs); err != nil {
+	if err := bm.efivars.SetVariable(efi.GlobalVariable, bootNextStr, bootNumBytes, bm.bootOrderAttrs); err != nil {
 		return err
 	}
 

--- a/efibootmgr/bootmgr.go
+++ b/efibootmgr/bootmgr.go
@@ -20,6 +20,7 @@ import (
 const (
 	maxBootEntries = 65535 // Maximum number of boot entries we can hold
 )
+const invalidBootNumber = -1
 const defaultBootVariableAttributes = efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess
 
 type BootVarNotFoundError struct {
@@ -131,13 +132,13 @@ func (bm *BootManager) NextFreeEntry() (int, error) {
 		}
 	}
 
-	return -1, fmt.Errorf("Maximum number of boot entries exceeded")
+	return invalidBootNumber, fmt.Errorf("Maximum number of boot entries exceeded")
 }
 
 // FindOrCreateEntry finds a matching entry in the boot device selection menu,
 // or creates one if it is missing.
 //
-// It returns the number of the entry created, or -1 on failure, with error set.
+// It returns the number of the entry created, or invalidBootNumber on failure, with error set.
 //
 // The argument relativeTo specifies the directory entry.Filename is in.
 func (bm *BootManager) FindOrCreateEntry(entry BootEntry, relativeTo string) (int, error) {
@@ -148,7 +149,7 @@ func (bm *BootManager) FindOrCreateEntry(entry BootEntry, relativeTo string) (in
 		var notFoundError *BootVarNotFoundError
 		if !errors.As(err, &notFoundError) {
 			err = fmt.Errorf("unable to determine if boot entry %s exists: %w", entry.Label, err)
-			return -1, err
+			return invalidBootNumber, err
 		}
 	}
 
@@ -156,16 +157,16 @@ func (bm *BootManager) FindOrCreateEntry(entry BootEntry, relativeTo string) (in
 	dpStr := path.Join(relativeTo, entry.Filename)
 	dp, err := bm.efivars.NewFileDevicePath(dpStr, efi_linux.ShortFormPathHD)
 	if err != nil {
-		return -1, fmt.Errorf("unable to derive device path %s: %w", dpStr, err)
+		return invalidBootNumber, fmt.Errorf("unable to derive device path %s: %w", dpStr, err)
 	}
 	freeEntryNumber, err := bm.NextFreeEntry()
 	if err != nil {
-		return -1, fmt.Errorf("unable to generate a new boot number: %w", err)
+		return invalidBootNumber, fmt.Errorf("unable to generate a new boot number: %w", err)
 	}
 
 	entryVar, err := NewBootEntryVariable(entry, freeEntryNumber, dp)
 	if err != nil {
-		return -1, fmt.Errorf("unable to create the boot entry variable: %w", err)
+		return invalidBootNumber, fmt.Errorf("unable to create the boot entry variable: %w", err)
 	}
 
 	// Entry needs to be added as a boot entry

--- a/efibootmgr/bootmgr.go
+++ b/efibootmgr/bootmgr.go
@@ -69,6 +69,7 @@ type BootManager struct {
 	entries        map[int]BootEntryVariable // The Boot<number> variables
 	bootOrder      []int                     // The BootOrder variable, parsed
 	bootCurrent    int                       // The BootCurrent variable, parsed
+	bootNext       int                       // The BootNext variable, parsed
 	bootOrderAttrs efi.VariableAttributes    // The attributes of BootOrder variable
 }
 
@@ -82,6 +83,7 @@ func NewBootManagerForVariables(efivars EFIVariables) (BootManager, error) {
 	var err error
 	bm := BootManager{}
 	bm.efivars = efivars
+	bm.bootNext = invalidBootNumber
 
 	if !VariablesSupported(efivars) {
 		return BootManager{}, fmt.Errorf("Variables not supported")
@@ -100,6 +102,13 @@ func NewBootManagerForVariables(efivars EFIVariables) (BootManager, error) {
 		}
 	} else {
 		bm.bootCurrent = int(binary.LittleEndian.Uint16(bootCurrentBytes[0:2]))
+	}
+
+	// It's possible that BootNext is active from user input or a previous iteration of nullboot
+	if bootNextBytes, _, err := bm.efivars.GetVariable(efi.GlobalVariable, "BootNext"); err != nil {
+		if len(bootNextBytes) != 0 {
+			bm.bootNext = int(binary.LittleEndian.Uint16(bootNextBytes[0:2]))
+		}
 	}
 
 	bootOrderBytes, bootOrderAttrs, err := bm.efivars.GetVariable(efi.GlobalVariable, "BootOrder")
@@ -271,7 +280,15 @@ func (bm *BootManager) DeleteEntry(bootNum int) error {
 	// removing this entry won't lead to any **more** mistakes.
 	if bootNum == bm.bootCurrent {
 		log.Printf("the entry associated to BootCurrent (%s) has been deleted\n", toEFIBootEntryFormat(bootNum))
+	} else if bootNum == bm.bootNext {
+		log.Printf("the entry associated to BootNext (%s) has been deleted and un-set\n", toEFIBootEntryFormat(bootNum))
+		if err := DelVariable(bm.efivars, efi.GlobalVariable, "BootNext"); err != nil {
+			return err
+		}
+
+		bm.bootNext = invalidBootNumber
 	}
+
 	var newOrder []int
 
 	for _, orderEntry := range bm.bootOrder {
@@ -309,8 +326,7 @@ func (bm *BootManager) PrependAndSetBootOrder(head []int) error {
 	// Encode the boot order to bytes
 	var output []byte
 	for _, num := range newOrder {
-		var numBytes [2]byte
-		binary.LittleEndian.PutUint16(numBytes[0:], uint16(num))
+		numBytes := toEFIBootEntryBytes(num)
 		output = append(output, numBytes[0], numBytes[1])
 	}
 
@@ -331,6 +347,24 @@ func toEFIBootEntryFormat(bootNum int) string {
 	return fmt.Sprintf("Boot%04X", bootNum)
 }
 
+// SetBootNext sets the system BootNext variable to the encoded value of
+// the input boot number.
+//
+// Returns an error in the event that the variable cannot be set.
+func (bm *BootManager) SetBootNext(bootNum int) error {
+	bootEntryName := toEFIBootEntryFormat(bootNum)
+	if _, _, err := bm.efivars.GetVariable(efi.GlobalVariable, bootEntryName); err != nil {
+		return fmt.Errorf("unable to find %s: %w", bootEntryName, err)
+	}
+	bootNumBytes := toEFIBootEntryBytes(bootNum)
+	if err := bm.efivars.SetVariable(efi.GlobalVariable, "BootNext", bootNumBytes, bm.bootOrderAttrs); err != nil {
+		return err
+	}
+
+	bm.bootNext = bootNum
+	return nil
+}
+
 // newEFILoadOption derives a standardized LoadOption from a specified entry
 // and device path.
 //
@@ -345,4 +379,13 @@ func newEFILoadOption(entry BootEntry, dp efi.DevicePath) *efi.LoadOption {
 		OptionalData: optionalData.Bytes()}
 
 	return loadOption
+}
+
+// toEFIBootEntryBytes converts a boot number integer into the system format.
+//
+// Returns a 2-length []byte of little-endian oriented uint16s.
+func toEFIBootEntryBytes(bootNum int) []byte {
+	numBytes := make([]byte, 2)
+	binary.LittleEndian.PutUint16(numBytes[:], uint16(bootNum))
+	return numBytes
 }

--- a/efibootmgr/bootmgr.go
+++ b/efibootmgr/bootmgr.go
@@ -8,6 +8,7 @@ package efibootmgr
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log"
 	"path"
@@ -19,6 +20,20 @@ import (
 const (
 	maxBootEntries = 65535 // Maximum number of boot entries we can hold
 )
+const defaultBootVariableAttributes = efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess
+
+type BootVarNotFoundError struct {
+	Message string
+	Err     error
+}
+
+func (e BootVarNotFoundError) Error() string {
+	return e.Message
+}
+
+func (e BootVarNotFoundError) Unwrap() error {
+	return e.Err
+}
 
 // BootEntryVariable defines a boot entry variable
 type BootEntryVariable struct {
@@ -26,6 +41,25 @@ type BootEntryVariable struct {
 	Data       []byte                 // the data of the variable
 	Attributes efi.VariableAttributes // any attributes set on the variable
 	LoadOption *efi.LoadOption        // the data of the variable parsed as a load option, if it is a valid load option
+}
+
+// NewBootEntryVariable creates a BootEntryVariable derived from a BootEntry,
+// given a boot number and device path.
+func NewBootEntryVariable(entry BootEntry, bootNum int, dp efi.DevicePath) (BootEntryVariable, error) {
+	loadOption := newEFILoadOption(entry, dp)
+	data, err := loadOption.Bytes()
+	if err != nil {
+		return BootEntryVariable{}, fmt.Errorf("cannot encode boot entry data: %w", err)
+	}
+
+	entryVar := BootEntryVariable{
+		BootNumber: bootNum,
+		Data:       data,
+		Attributes: defaultBootVariableAttributes,
+		LoadOption: loadOption,
+	}
+
+	return entryVar, nil
 }
 
 // BootManager manages the boot device selection menu entries (Boot0000...BootFFFF).
@@ -107,52 +141,91 @@ func (bm *BootManager) NextFreeEntry() (int, error) {
 //
 // The argument relativeTo specifies the directory entry.Filename is in.
 func (bm *BootManager) FindOrCreateEntry(entry BootEntry, relativeTo string) (int, error) {
-	bootNext, err := bm.NextFreeEntry()
-	if err != nil {
-		return -1, err
-	}
-	variable := fmt.Sprintf("Boot%04X", bootNext)
-
-	dp, err := bm.efivars.NewFileDevicePath(path.Join(relativeTo, entry.Filename), efi_linux.ShortFormPathHD)
-	if err != nil {
-		return -1, err
-	}
-
-	optionalData := new(bytes.Buffer)
-	binary.Write(optionalData, binary.LittleEndian, efi.ConvertUTF8ToUCS2(entry.Options+"\x00"))
-
-	loadoption := &efi.LoadOption{
-		Attributes:   efi.LoadOptionActive,
-		Description:  entry.Label,
-		FilePath:     dp,
-		OptionalData: optionalData.Bytes()}
-
-	loadoptionBytes, err := loadoption.Bytes()
-	if err != nil {
-		return -1, fmt.Errorf("cannot encode load option: %v", err)
-	}
-
-	entryVar := BootEntryVariable{
-		BootNumber: bootNext,
-		Data:       loadoptionBytes,
-		Attributes: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess,
-		LoadOption: loadoption,
-	}
-
-	// Detect duplicates and ignore
-	for _, existingVar := range bm.entries {
-		if bytes.Equal(existingVar.Data, entryVar.Data) && existingVar.Attributes == entryVar.Attributes {
-			return existingVar.BootNumber, nil
+	bootEntryVar, err := bm.FindBootEntryVariable(entry, relativeTo)
+	if err == nil {
+		return bootEntryVar.BootNumber, nil
+	} else {
+		var notFoundError *BootVarNotFoundError
+		if !errors.As(err, &notFoundError) {
+			err = fmt.Errorf("unable to determine if boot entry %s exists: %w", entry.Label, err)
+			return -1, err
 		}
 	}
 
-	if err := bm.efivars.SetVariable(efi.GlobalVariable, variable, entryVar.Data, entryVar.Attributes); err != nil {
-		return -1, err
+	// Entry was not found; generate requisite data
+	dpStr := path.Join(relativeTo, entry.Filename)
+	dp, err := bm.efivars.NewFileDevicePath(dpStr, efi_linux.ShortFormPathHD)
+	if err != nil {
+		return -1, fmt.Errorf("unable to derive device path %s: %w", dpStr, err)
+	}
+	freeEntryNumber, err := bm.NextFreeEntry()
+	if err != nil {
+		return -1, fmt.Errorf("unable to generate a new boot number: %w", err)
 	}
 
-	bm.entries[bootNext] = entryVar
+	entryVar, err := NewBootEntryVariable(entry, freeEntryNumber, dp)
+	if err != nil {
+		return -1, fmt.Errorf("unable to create the boot entry variable: %w", err)
+	}
 
-	return bootNext, nil
+	// Entry needs to be added as a boot entry
+	err = bm.RegisterBootEntryVariable(entryVar)
+	if err != nil {
+		return entryVar.BootNumber, fmt.Errorf(
+			"unable to set environment variables for %s: %w",
+			toEFIBootEntryFormat(entryVar.BootNumber),
+			err,
+		)
+	}
+	bm.entries[freeEntryNumber] = entryVar
+	return entryVar.BootNumber, nil
+}
+
+// FindBootEntryVariable finds a matching BootEntryVariable from the boot
+// device selection menu associated to the input BootEntry in a relative
+// directory.
+//
+// The argument relativeTo specifies the directory entry.Filename is in.
+//
+// If a BootEntryVariable cannot be found, returns BootVarNotFoundError.
+func (bm *BootManager) FindBootEntryVariable(entry BootEntry, relativeTo string) (BootEntryVariable, error) {
+	dp, err := bm.efivars.NewFileDevicePath(path.Join(relativeTo, entry.Filename), efi_linux.ShortFormPathHD)
+	if err != nil {
+		return BootEntryVariable{}, fmt.Errorf("unable to derive device path: %w", err)
+	}
+
+	loadOption := newEFILoadOption(entry, dp)
+	data, err := loadOption.Bytes()
+	if err != nil {
+		return BootEntryVariable{}, fmt.Errorf("unable to encode load option for %s: %w", entry.Label, err)
+	}
+
+	for _, existingVar := range bm.entries {
+		if bytes.Equal(existingVar.Data, data) && existingVar.Attributes == defaultBootVariableAttributes {
+			return existingVar, nil
+		}
+	}
+
+	err = fmt.Errorf("unable to find %s in the registered EFI boot variables: %w", entry.Label, err)
+	notFoundErr := BootVarNotFoundError{
+		Message: err.Error(),
+		Err:     err,
+	}
+	return BootEntryVariable{}, &notFoundErr
+}
+
+// RegisterBootEntryVariable registers a system boot variable to the
+// bm.efivars and bm.entries.
+//
+// It returns an error should there be an issue registering the system variable.
+func (bm *BootManager) RegisterBootEntryVariable(entryVar BootEntryVariable) error {
+	variable := toEFIBootEntryFormat(entryVar.BootNumber)
+
+	if err := bm.efivars.SetVariable(efi.GlobalVariable, variable, entryVar.Data, entryVar.Attributes); err != nil {
+		return err
+	}
+	bm.entries[entryVar.BootNumber] = entryVar
+	return nil
 }
 
 // DeleteEntry deletes an entry and updates the cached boot order.
@@ -163,7 +236,7 @@ func (bm *BootManager) FindOrCreateEntry(entry BootEntry, relativeTo string) (in
 // and then create a new one with the same number we don't accidentally have the new one in
 // the order.
 func (bm *BootManager) DeleteEntry(bootNum int) error {
-	variable := fmt.Sprintf("Boot%04X", bootNum)
+	variable := toEFIBootEntryFormat(bootNum)
 	if _, ok := bm.entries[bootNum]; !ok {
 		return fmt.Errorf("Tried deleting a non-existing variable %s", variable)
 	}
@@ -223,4 +296,27 @@ func (bm *BootManager) PrependAndSetBootOrder(head []int) error {
 	bm.bootOrder = newOrder
 	return nil
 
+}
+
+// toEFIBootEntryFormat generates the Boot Name associated to the specified integer
+// and formats it to match the EFI Boot Entry style:
+// i.e. toEFIBootEntryFormat(1) -> "Boot0001", toEFIBootEntryFormat(43) -> "Boot002B", ...
+func toEFIBootEntryFormat(bootNum int) string {
+	return fmt.Sprintf("Boot%04X", bootNum)
+}
+
+// newEFILoadOption derives a standardized LoadOption from a specified entry
+// and device path.
+//
+// It returns a pointer to the new LoadOption.
+func newEFILoadOption(entry BootEntry, dp efi.DevicePath) *efi.LoadOption {
+	optionalData := new(bytes.Buffer)
+	binary.Write(optionalData, binary.LittleEndian, efi.ConvertUTF8ToUCS2(entry.Options+"\x00"))
+	loadOption := &efi.LoadOption{
+		Attributes:   efi.LoadOptionActive,
+		Description:  entry.Label,
+		FilePath:     dp,
+		OptionalData: optionalData.Bytes()}
+
+	return loadOption
 }

--- a/efibootmgr/bootmgr.go
+++ b/efibootmgr/bootmgr.go
@@ -68,6 +68,7 @@ type BootManager struct {
 	efivars        EFIVariables              // EFIVariables implementation
 	entries        map[int]BootEntryVariable // The Boot<number> variables
 	bootOrder      []int                     // The BootOrder variable, parsed
+	bootCurrent    int                       // The BootCurrent variable, parsed
 	bootOrderAttrs efi.VariableAttributes    // The attributes of BootOrder variable
 }
 
@@ -84,6 +85,21 @@ func NewBootManagerForVariables(efivars EFIVariables) (BootManager, error) {
 
 	if !VariablesSupported(efivars) {
 		return BootManager{}, fmt.Errorf("Variables not supported")
+	}
+
+	if bootCurrentBytes, _, err := bm.efivars.GetVariable(efi.GlobalVariable, "BootCurrent"); err != nil {
+		switch bm.efivars.(type) {
+		// BootCurrent is a volatile entry that is created upon a
+		// successful boot into some boot entry. Since MockEFIVariables is
+		// not representing a live host, BootCurrent does not need to exist
+		case *MockEFIVariables:
+			log.Printf("Could not read BootCurrent variable, populating with default (%d), error was: %v\n", invalidBootNumber, err)
+			bm.bootCurrent = invalidBootNumber
+		default:
+			return BootManager{}, fmt.Errorf("could not read BootCurrent variable, error was: %w\n", err)
+		}
+	} else {
+		bm.bootCurrent = int(binary.LittleEndian.Uint16(bootCurrentBytes[0:2]))
 	}
 
 	bootOrderBytes, bootOrderAttrs, err := bm.efivars.GetVariable(efi.GlobalVariable, "BootOrder")
@@ -247,6 +263,15 @@ func (bm *BootManager) DeleteEntry(bootNum int) error {
 	}
 	delete(bm.entries, bootNum)
 
+	// Deleting BootCurrent is not a good idea. It can put your system at
+	// risk. apt won't delete the user's BootCurrent artifacts, so this has
+	// to be an action caused by a bug or a mistaken user; however, if the
+	// user truly deleted all artifacts associated to BootCurrent, the FDE
+	// key is likely resealed at this point without those artifacts, and
+	// removing this entry won't lead to any **more** mistakes.
+	if bootNum == bm.bootCurrent {
+		log.Printf("the entry associated to BootCurrent (%s) has been deleted\n", toEFIBootEntryFormat(bootNum))
+	}
 	var newOrder []int
 
 	for _, orderEntry := range bm.bootOrder {

--- a/efibootmgr/bootmgr_test.go
+++ b/efibootmgr/bootmgr_test.go
@@ -180,6 +180,59 @@ func TestBootManagerSetBootOrder(t *testing.T) {
 	}
 }
 
+func TestBootManagerSetBootNext(t *testing.T) {
+	mockvars := MockEFIVariables{
+		map[efi.VariableDescriptor]mockEFIVariable{
+			{GUID: efi.GlobalVariable, Name: "BootOrder"}: {[]byte{1, 0, 2, 0, 3, 0}, 123},
+			{GUID: efi.GlobalVariable, Name: "Boot0001"}:  {UsbrBootCdromOptBytes, 42},
+		},
+	}
+	expected := 1
+	expectedBytes := toEFIBootEntryBytes(expected)
+	expectedName := toEFIBootEntryFormat(expected)
+	bm, err := NewBootManagerForVariables(&mockvars)
+	if err != nil {
+		t.Fatalf("Could not create boot manager: %v", err)
+	}
+	if err := bm.SetBootNext(expected); err != nil {
+		t.Fatalf("Could not set BootNext to %s: %v", expectedName, err)
+	}
+
+	if bm.bootNext != expected {
+		t.Errorf("Expected internal bootNext to be %d, got %v", expected, bm.bootNext)
+	}
+	bootNextBytes := mockvars.store[efi.VariableDescriptor{GUID: efi.GlobalVariable, Name: "BootNext"}].data
+	if !bytes.Equal(bootNextBytes, expectedBytes) {
+		t.Errorf("Expected actual BootNext to be %v, got %v.", expectedBytes, bootNextBytes)
+	}
+}
+
+func TestBootManagerSetBootNextFail(t *testing.T) {
+	mockvars := MockEFIVariables{
+		map[efi.VariableDescriptor]mockEFIVariable{},
+	}
+	bm, err := NewBootManagerForVariables(&mockvars)
+	if err != nil {
+		t.Fatalf("Could not create boot manager: %v", err)
+	}
+	// No variables exist, so this should fail
+	if err := bm.SetBootNext(0); err == nil {
+		t.Error("SetBootNext should fail to complete")
+	}
+
+	if bm.bootNext != invalidBootNumber {
+		t.Errorf(
+			"Expected internal bootNext to be %d, got %d",
+			invalidBootNumber,
+			bm.bootNext,
+		)
+	}
+	bootNextBytes := mockvars.store[efi.VariableDescriptor{GUID: efi.GlobalVariable, Name: "BootNext"}].data
+	if !bytes.Equal(bootNextBytes, []byte{}) {
+		t.Errorf("Expected actual BootNext to be empty, got %v.", bootNextBytes)
+	}
+}
+
 func TestBootManager_json(t *testing.T) {
 	memFs := afero.NewMemMapFs()
 	appFs = MapFS{memFs}

--- a/efibootmgr/kernel.go
+++ b/efibootmgr/kernel.go
@@ -220,10 +220,10 @@ func (km *KernelManager) CommitToBootLoader() error {
 // Returns an error if the entry does not yet exist as a BootEntryVariable
 // or if there is an error setting BootNext.
 func (km *KernelManager) SetLatestKernelToBootNext() error {
-	// NOTE: km.bootEntries[0] is expected to be latest kernel due to the
-	// readKernels method that orders kernels by version before they are
-	// installed and populated into bootEntries via InstallKernels
-	latestKernel := km.bootEntries[0]
+	latestKernel, err := km.GetLatestKernelEntry()
+	if err != nil {
+		return fmt.Errorf("unable to get latest kernel entry: %w", err)
+	}
 	latestKernelEntryVar, err := km.bootManager.FindBootEntryVariable(latestKernel, km.targetDir)
 	if err != nil {
 		return fmt.Errorf("unable to find boot variable for %s, %v: %w", latestKernel.Label, latestKernel.Options, err)
@@ -233,4 +233,36 @@ func (km *KernelManager) SetLatestKernelToBootNext() error {
 	}
 
 	return nil
+}
+
+func (km *KernelManager) IsCurrentBootLatest() (bool, error) {
+	if len(km.bootEntries) == 0 {
+		return false, fmt.Errorf("no Ubuntu Kernel EFIs have been loaded")
+	}
+
+	latestKernelEntry, err := km.GetLatestKernelEntry()
+	if err != nil {
+		return false, fmt.Errorf("unable to get latest kernel entry: %w", err)
+	}
+	latestKernelEntryVar, err := km.bootManager.FindBootEntryVariable(latestKernelEntry, km.targetDir)
+	if err != nil {
+		return false, fmt.Errorf("unable to find latest kernel boot variable: %w", err)
+	}
+
+	// Determine if the BootEntryVariable is the BootCurrent variable
+	if latestKernelEntryVar.BootNumber == km.bootManager.bootCurrent {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+func (km *KernelManager) GetLatestKernelEntry() (BootEntry, error) {
+	// NOTE: km.bootEntries[0] is expected to be latest kernel due to the
+	// readKernels method that orders kernels by version before they are
+	// installed and populated into bootEntries via InstallKernels
+	if len(km.bootEntries) > 0 {
+		return km.bootEntries[0], nil
+	}
+	return BootEntry{}, fmt.Errorf("no kernels have been registered to the KernelManager")
 }

--- a/efibootmgr/kernel.go
+++ b/efibootmgr/kernel.go
@@ -117,6 +117,18 @@ func (km *KernelManager) InstallKernels() error {
 	return nil
 }
 
+// RegisterNewKernelEFIs creates EFI variables for each new kernel
+// installed via InstallKernels, adding them to the BootManager and
+// creating the variables on the host machine.
+func (km *KernelManager) RegisterNewKernelEFIs() error {
+	for _, entry := range km.bootEntries {
+		if _, err := km.bootManager.FindOrCreateEntry(entry, km.targetDir); err != nil {
+			return fmt.Errorf("unable to find or create EFI boot entry for %s: %w", entry.Label, err)
+		}
+	}
+	return nil
+}
+
 // IsObsoleteKernel checks whether a kernel is obsolete.
 func (km *KernelManager) isObsoleteKernel(k string) bool {
 	for _, sk := range km.sourceKernels {
@@ -168,11 +180,11 @@ func (km *KernelManager) CommitToBootLoader() error {
 
 	// Add new entries, find existing ones and build target boot order
 	for _, entry := range km.bootEntries {
-		bootNum, err := km.bootManager.FindOrCreateEntry(entry, km.targetDir)
+		entryVar, err := km.bootManager.FindBootEntryVariable(entry, km.targetDir)
 		if err != nil {
-			return fmt.Errorf("Failure to add boot entry for %s: %w", entry.Label, err)
+			return fmt.Errorf("failure to find boot entry for %s: %w", entry.Label, err)
 		}
-		ourBootOrder = append(ourBootOrder, bootNum)
+		ourBootOrder = append(ourBootOrder, entryVar.BootNumber)
 	}
 
 	// Delete any obsolete kernels

--- a/efibootmgr/kernel.go
+++ b/efibootmgr/kernel.go
@@ -214,3 +214,23 @@ func (km *KernelManager) CommitToBootLoader() error {
 
 	return nil
 }
+
+// SetLatestKernelToBootNext sets the latest kernel to be BootNext.
+//
+// Returns an error if the entry does not yet exist as a BootEntryVariable
+// or if there is an error setting BootNext.
+func (km *KernelManager) SetLatestKernelToBootNext() error {
+	// NOTE: km.bootEntries[0] is expected to be latest kernel due to the
+	// readKernels method that orders kernels by version before they are
+	// installed and populated into bootEntries via InstallKernels
+	latestKernel := km.bootEntries[0]
+	latestKernelEntryVar, err := km.bootManager.FindBootEntryVariable(latestKernel, km.targetDir)
+	if err != nil {
+		return fmt.Errorf("unable to find boot variable for %s, %v: %w", latestKernel.Label, latestKernel.Options, err)
+	}
+	if err := km.bootManager.SetBootNext(latestKernelEntryVar.BootNumber); err != nil {
+		return fmt.Errorf("unable to set BootNext to Boot%04X (%s): %w", latestKernelEntryVar.BootNumber, latestKernel.Label, err)
+	}
+
+	return nil
+}

--- a/efibootmgr/kernel.go
+++ b/efibootmgr/kernel.go
@@ -108,20 +108,10 @@ func (km *KernelManager) InstallKernels() error {
 		if updated {
 			log.Printf("Installed or updated kernel %s", sk)
 		}
-		// It is worth pointing out that the argument for shim should start with \
-		// which here somehow denotes it is in the same directory rather than the root.
-		// FIXME: Extract vendor name out into config file
-		skVersion := getKernelABI(sk)
-		options := "\\" + sk
-		if km.kernelOptions != "" {
-			options += " " + km.kernelOptions
-		}
-		km.bootEntries = append(km.bootEntries, BootEntry{
-			Filename:    "shim" + GetEfiArchitecture() + ".efi",
-			Label:       fmt.Sprintf("Ubuntu with kernel %s", skVersion),
-			Options:     options,
-			Description: fmt.Sprintf("Ubuntu entry for kernel %s", skVersion),
-		})
+		km.bootEntries = append(
+			km.bootEntries,
+			NewKernelBootEntry("Ubuntu", sk, km.kernelOptions),
+		)
 	}
 
 	return nil

--- a/efibootmgr/kernel.go
+++ b/efibootmgr/kernel.go
@@ -15,18 +15,50 @@ import (
 	"github.com/knqyf263/go-deb-version"
 )
 
+const kernelPrefix = "kernel.efi-"
+
+type Kernel struct {
+	Version  version.Version
+	FilePath string
+}
+
+func (k *Kernel) GetKernelName() string {
+	return path.Base(k.FilePath)
+}
+
+func (k *Kernel) Equals(other Kernel) bool {
+	return k.Version.Equal(other.Version) && k.GetKernelName() == other.GetKernelName()
+}
+
+func NewKernel(kernelPath string) (Kernel, error) {
+	kernelName := path.Base(kernelPath)
+	if versionStr, err := getKernelABI(kernelName); err == nil {
+		v, err := version.NewVersion(versionStr)
+		if err != nil {
+			return Kernel{}, fmt.Errorf("could not parse kernel version of %s: %w", kernelName, err)
+		}
+		return Kernel{v, kernelPath}, nil
+	}
+	return Kernel{}, fmt.Errorf("unrecognized kernel naming format: %s", kernelName)
+}
+
+type KernelEntry struct {
+	kernel    Kernel
+	bootEntry BootEntry
+}
+
 // KernelManager manages kernels in an SP vendor directory.
 //
 // It will update or install shim, copy in any new kernels,
 // remove old kernels, and configure boot in shim and BDS.
 type KernelManager struct {
-	sourceDir     string       // sourceDir is the location to copy kernels from
-	targetDir     string       // targetDir is a vendor directory on the ESP
-	sourceKernels []string     // kernels in sourceDir
-	targetKernels []string     // kernels in targetDir
-	bootEntries   []BootEntry  // boot entries filled by InstallKernels
-	kernelOptions string       // options to pass to kernel
-	bootManager   *BootManager // The EFI boot manager
+	sourceDir     string        // sourceDir is the location to copy kernels from
+	targetDir     string        // targetDir is a vendor directory on the ESP
+	sourceKernels []Kernel      // kernels in sourceDir
+	targetKernels []Kernel      // kernels in targetDir
+	kernelEntries []KernelEntry // boot entries filled by InstallKernels
+	kernelOptions string        // options to pass to kernel
+	bootManager   *BootManager  // The EFI boot manager
 }
 
 // NewKernelManager returns a new kernel manager managing kernels in the host system
@@ -60,58 +92,62 @@ func NewKernelManager(esp, sourceDir, vendor string, bootManager *BootManager) (
 	return &km, nil
 }
 
-// readKernels returns a list of all kernels in the
-func (km *KernelManager) readKernels(dir string) ([]string, error) {
-	var kernels []string
+// readKernels returns a list of all kernels in the given directory
+func (km *KernelManager) readKernels(dir string) ([]Kernel, error) {
+	var kernels []Kernel
 	entries, err := appFs.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("Could not determine kernels: %w", err)
 	}
 	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), "kernel.efi-") {
-			kernels = append(kernels, e.Name())
+		if !hasKernelPrefix(e.Name()) {
+			continue
 		}
+		kernel, err := NewKernel(path.Join(dir, e.Name()))
+		if err != nil {
+			return []Kernel{}, err
+		}
+		kernels = append(kernels, kernel)
 	}
 	// Sort descending
 	sort.Slice(kernels, func(i, j int) bool {
-		a, e := version.NewVersion(kernels[i][len("kernel.efi-"):])
-		if e != nil {
-			err = fmt.Errorf("Could not parse kernel version of %s: %w", kernels[i], e)
-			return false
-		}
-		b, e := version.NewVersion(kernels[j][len("kernel.efi-"):])
-		if e != nil {
-			err = fmt.Errorf("Could not parse kernel version of %s: %w", kernels[j], e)
-			return false
-		}
+		a := kernels[i].Version
+		b := kernels[j].Version
 		return a.GreaterThan(b)
 	})
 	return kernels, err
 }
 
 // getKernelABI returns the kernel ABI part of the kernel filename
-func getKernelABI(kernel string) string {
-	return kernel[len("kernel.efi-"):]
+func getKernelABI(kernel string) (string, error) {
+	if hasKernelPrefix(kernel) {
+		return kernel[len(kernelPrefix):], nil
+	}
+	return "", fmt.Errorf("unknown naming format of kernel %s, unable to parse ABI", kernel)
+}
+
+func hasKernelPrefix(kernel string) bool {
+	return strings.HasPrefix(kernel, kernelPrefix)
 }
 
 // InstallKernels installs the kernels to the ESP and builds up the boot entries
 // to commit using CommitToBootLoader()
 func (km *KernelManager) InstallKernels() error {
-	km.bootEntries = nil
+	km.kernelEntries = nil
 	for _, sk := range km.sourceKernels {
-		updated, err := MaybeUpdateFile(path.Join(km.targetDir, sk),
-			path.Join(km.sourceDir, sk))
+		kName := sk.GetKernelName()
+		tkFilePath := path.Join(km.targetDir, kName)
+		updated, err := MaybeUpdateFile(tkFilePath, sk.FilePath)
 		if err != nil {
-			log.Printf("Could not install kernel %s: %v", sk, err)
+			log.Printf("Could not install kernel %s: %v", kName, err)
 			continue
 		}
 		if updated {
-			log.Printf("Installed or updated kernel %s", sk)
+			log.Printf("Installed or updated kernel %s", kName)
 		}
-		km.bootEntries = append(
-			km.bootEntries,
-			NewKernelBootEntry("Ubuntu", sk, km.kernelOptions),
-		)
+
+		bootEntry := NewKernelBootEntry("Ubuntu", sk, km.kernelOptions)
+		km.kernelEntries = append(km.kernelEntries, KernelEntry{sk, bootEntry})
 	}
 
 	return nil
@@ -121,7 +157,8 @@ func (km *KernelManager) InstallKernels() error {
 // installed via InstallKernels, adding them to the BootManager and
 // creating the variables on the host machine.
 func (km *KernelManager) RegisterNewKernelEFIs() error {
-	for _, entry := range km.bootEntries {
+	for _, ke := range km.kernelEntries {
+		entry := ke.bootEntry
 		if _, err := km.bootManager.FindOrCreateEntry(entry, km.targetDir); err != nil {
 			return fmt.Errorf("unable to find or create EFI boot entry for %s: %w", entry.Label, err)
 		}
@@ -130,9 +167,9 @@ func (km *KernelManager) RegisterNewKernelEFIs() error {
 }
 
 // IsObsoleteKernel checks whether a kernel is obsolete.
-func (km *KernelManager) isObsoleteKernel(k string) bool {
+func (km *KernelManager) isObsoleteKernel(k Kernel) bool {
 	for _, sk := range km.sourceKernels {
-		if sk == k {
+		if sk.Equals(k) {
 			return false
 		}
 	}
@@ -141,18 +178,18 @@ func (km *KernelManager) isObsoleteKernel(k string) bool {
 
 // RemoveObsoleteKernels removes old kernels in the ESP vendor directory
 func (km *KernelManager) RemoveObsoleteKernels() error {
-	var remaining []string
+	var remaining []Kernel
 	for _, tk := range km.targetKernels {
 		if !km.isObsoleteKernel(tk) {
 			continue
 		}
-		if err := appFs.Remove(path.Join(km.targetDir, tk)); err != nil {
-			log.Printf("Could not remove kernel %s: %v", tk, err)
+		if err := appFs.Remove(tk.FilePath); err != nil {
+			log.Printf("Could not remove kernel %s: %v", tk.FilePath, err)
 			remaining = append(remaining, tk)
 			continue
 		}
 
-		log.Printf("Removed kernel %s", tk)
+		log.Printf("Removed kernel %s", tk.FilePath)
 	}
 
 	km.targetKernels = remaining
@@ -163,9 +200,13 @@ func (km *KernelManager) RemoveObsoleteKernels() error {
 // CommitToBootLoader updates the firmware BDS entries and shim's boot.csv
 func (km *KernelManager) CommitToBootLoader() error {
 	log.Print("Configuring shim fallback loader")
+	bootEntries := []BootEntry{}
+	for _, ke := range km.kernelEntries {
+		bootEntries = append(bootEntries, ke.bootEntry)
+	}
 
 	// We completely own the shim fallback file, so just write it
-	if err := WriteShimFallbackToFile(path.Join(km.targetDir, "BOOT"+strings.ToUpper(GetEfiArchitecture())+".CSV"), km.bootEntries); err != nil {
+	if err := WriteShimFallbackToFile(path.Join(km.targetDir, "BOOT"+strings.ToUpper(GetEfiArchitecture())+".CSV"), bootEntries); err != nil {
 		log.Printf("Failed to configure shim fallback loader: %v", err)
 	}
 
@@ -179,7 +220,7 @@ func (km *KernelManager) CommitToBootLoader() error {
 	var ourBootOrder []int
 
 	// Add new entries, find existing ones and build target boot order
-	for _, entry := range km.bootEntries {
+	for _, entry := range bootEntries {
 		entryVar, err := km.bootManager.FindBootEntryVariable(entry, km.targetDir)
 		if err != nil {
 			return fmt.Errorf("failure to find boot entry for %s: %w", entry.Label, err)
@@ -220,23 +261,24 @@ func (km *KernelManager) CommitToBootLoader() error {
 // Returns an error if the entry does not yet exist as a BootEntryVariable
 // or if there is an error setting BootNext.
 func (km *KernelManager) SetLatestKernelToBootNext() error {
-	latestKernel, err := km.GetLatestKernelEntry()
+	latestKernelEntry, err := km.GetLatestKernelEntry()
+	latestKernelBootEntry := latestKernelEntry.bootEntry
 	if err != nil {
 		return fmt.Errorf("unable to get latest kernel entry: %w", err)
 	}
-	latestKernelEntryVar, err := km.bootManager.FindBootEntryVariable(latestKernel, km.targetDir)
+	latestKernelEntryVar, err := km.bootManager.FindBootEntryVariable(latestKernelBootEntry, km.targetDir)
 	if err != nil {
-		return fmt.Errorf("unable to find boot variable for %s, %v: %w", latestKernel.Label, latestKernel.Options, err)
+		return fmt.Errorf("unable to find boot variable for %s: %w", latestKernelEntry.kernel.FilePath, err)
 	}
 	if err := km.bootManager.SetBootNext(latestKernelEntryVar.BootNumber); err != nil {
-		return fmt.Errorf("unable to set BootNext to Boot%04X (%s): %w", latestKernelEntryVar.BootNumber, latestKernel.Label, err)
+		return fmt.Errorf("unable to set BootNext to Boot%04X (%s): %w", latestKernelEntryVar.BootNumber, latestKernelEntry.kernel.FilePath, err)
 	}
 
 	return nil
 }
 
 func (km *KernelManager) IsCurrentBootLatest() (bool, error) {
-	if len(km.bootEntries) == 0 {
+	if len(km.kernelEntries) == 0 {
 		return false, fmt.Errorf("no Ubuntu Kernel EFIs have been loaded")
 	}
 
@@ -244,7 +286,7 @@ func (km *KernelManager) IsCurrentBootLatest() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("unable to get latest kernel entry: %w", err)
 	}
-	latestKernelEntryVar, err := km.bootManager.FindBootEntryVariable(latestKernelEntry, km.targetDir)
+	latestKernelEntryVar, err := km.bootManager.FindBootEntryVariable(latestKernelEntry.bootEntry, km.targetDir)
 	if err != nil {
 		return false, fmt.Errorf("unable to find latest kernel boot variable: %w", err)
 	}
@@ -257,12 +299,18 @@ func (km *KernelManager) IsCurrentBootLatest() (bool, error) {
 	}
 }
 
-func (km *KernelManager) GetLatestKernelEntry() (BootEntry, error) {
-	// NOTE: km.bootEntries[0] is expected to be latest kernel due to the
-	// readKernels method that orders kernels by version before they are
-	// installed and populated into bootEntries via InstallKernels
-	if len(km.bootEntries) > 0 {
-		return km.bootEntries[0], nil
+// Returns the KernelEntry with the largest version in km.kernelEntries
+func (km *KernelManager) GetLatestKernelEntry() (KernelEntry, error) {
+	numEntries := len(km.kernelEntries)
+	if numEntries == 0 {
+		return KernelEntry{}, fmt.Errorf("no kernels have been registered to the KernelManager")
 	}
-	return BootEntry{}, fmt.Errorf("no kernels have been registered to the KernelManager")
+	latest := km.kernelEntries[0]
+	for _, ke := range km.kernelEntries[1:] {
+		curVersion := ke.kernel.Version
+		if curVersion.GreaterThan(latest.kernel.Version) {
+			latest = ke
+		}
+	}
+	return latest, nil
 }

--- a/efibootmgr/kernel_test.go
+++ b/efibootmgr/kernel_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/canonical/go-efilib"
+	efi_linux "github.com/canonical/go-efilib/linux"
 	"github.com/spf13/afero"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
@@ -305,4 +306,78 @@ func TestKernelManagerRegisterNewKernelEFIs(t *testing.T) {
 		}
 	}
 
+}
+
+func TestKernelManagerSetLatestKernelToBootNext(t *testing.T) {
+	// Setup mocked/global filesystem
+	appArchitecture = "x64"
+	memFs := afero.NewMemMapFs()
+	appFs = MapFS{memFs}
+
+	targetDir := "/boot/efi/EFI/ubuntu"
+	sourceDir := "/usr/lib/linux"
+
+	shimPath := path.Join(targetDir, "shimx64.efi")
+	afero.WriteFile(memFs, shimPath, []byte("file a"), 0644)
+
+	// Map a number of BootNumbers to a set of kernel versions
+	// NOTE: when reading files, "1" < "100", but "20" > "100"
+	// This setup ensures that `readKernels` is properly sorting on version
+	kernelVersionMap := map[int]string{
+		1: "1",
+		2: "100", // This will be the latest kernel
+		3: "20",
+	}
+
+	efivars := MockEFIVariables{}
+	bm, err := NewBootManagerForVariables(&efivars)
+	if err != nil {
+		t.Fatalf("Could not create boot manager: %v", err)
+	}
+
+	dp, err := efivars.NewFileDevicePath(shimPath, efi_linux.ShortFormPathHD)
+	if err != nil {
+		t.Fatalf("unable to create shim device path: %v", err)
+	}
+	for bootNumber, kernelVersion := range kernelVersionMap {
+		kernelName := fmt.Sprintf("kernel.efi-%s", kernelVersion)
+		kernelSourcePath := path.Join(sourceDir, kernelName)
+		kernelTargetPath := path.Join(targetDir, kernelName)
+
+		// Must be written to file to be read by NewKernelManager and InstallKernels
+		afero.WriteFile(memFs, kernelSourcePath, []byte(kernelName), 0644)
+		afero.WriteFile(memFs, kernelTargetPath, []byte(kernelName), 0644)
+
+		// NOTE: create entries this way in the test so boot number can be controlled
+		entry := NewKernelBootEntry("Ubuntu", kernelName, "")
+		bootEntryVariable, err := NewBootEntryVariable(entry, bootNumber, dp)
+		if err != nil {
+			t.Fatalf("unable to create boot entry variable for %s: %v", kernelName, err)
+		}
+		bm.RegisterBootEntryVariable(bootEntryVariable)
+	}
+
+	// This reads the kernel files in version order
+	km, err := NewKernelManager("/boot/efi", sourceDir, "ubuntu", &bm)
+	// Populate km.bootEntries (also in version order)
+	km.InstallKernels()
+
+	if err := km.SetLatestKernelToBootNext(); err != nil {
+		t.Fatalf("unexpected error setting latest kernel to BootNext: %v", err)
+	}
+
+	// Check BootNext is set correctly in BootManager and on mocked system
+	expectedInternalBootNext := 2
+	expectedSystemBootNext := toEFIBootEntryBytes(expectedInternalBootNext)
+	systemBootNext, _, err := km.bootManager.efivars.GetVariable(efi.GlobalVariable, "BootNext")
+	if err != nil {
+		t.Fatalf("unexpected error getting BootNext: %v", err)
+	}
+
+	if !bytes.Equal(systemBootNext, expectedSystemBootNext) {
+		t.Errorf("system BootNext is not correct, expected: %v, got: %v", expectedSystemBootNext, systemBootNext)
+	}
+	if km.bootManager.bootNext != expectedInternalBootNext {
+		t.Errorf("internal BootNext is not correct, expected: %v, got: %v", expectedInternalBootNext, km.bootManager.bootNext)
+	}
 }

--- a/efibootmgr/kernel_test.go
+++ b/efibootmgr/kernel_test.go
@@ -381,3 +381,101 @@ func TestKernelManagerSetLatestKernelToBootNext(t *testing.T) {
 		t.Errorf("internal BootNext is not correct, expected: %v, got: %v", expectedInternalBootNext, km.bootManager.bootNext)
 	}
 }
+
+func TestKernelManagerIsCurrentBootLatest(t *testing.T) {
+	tests := map[string]struct {
+		kernelVersionMap    map[int]string // Maps BootNumber to kernel version string
+		latestKernelVersion string         // Version string for the latest kernel version
+		bootCurrent         int            // boot number for BootCurrent
+		expected            bool
+		isErr               bool
+	}{
+		"BootCurrent is latest": {
+			kernelVersionMap: map[int]string{
+				1: "3",
+				3: "0",
+			},
+			latestKernelVersion: "3",
+			bootCurrent:         1,
+			expected:            true,
+			isErr:               false,
+		},
+		"BootCurrent is not latest": {
+			kernelVersionMap: map[int]string{
+				1: "1",
+				3: "3",
+			},
+			latestKernelVersion: "3",
+			bootCurrent:         1,
+			expected:            false,
+			isErr:               false,
+		},
+		"Latest not in boot entries": {
+			kernelVersionMap: map[int]string{
+				1: "1",
+				3: "0",
+			},
+			// Note that latestKernelVersion is not in kernelVersionMap
+			latestKernelVersion: "10",
+			bootCurrent:         1,
+			expected:            false,
+			isErr:               true,
+		},
+	}
+	for testName, tt := range tests {
+		t.Logf("Testing: %s", testName)
+
+		appArchitecture = "x64"
+		memFs := afero.NewMemMapFs()
+		appFs = MapFS{memFs}
+
+		mockEntries := make(map[int]BootEntryVariable)
+		targetDir := "/boot/efi/EFI/ubuntu"
+		shimPath := path.Join(targetDir, "shimx64.efi")
+		afero.WriteFile(memFs, shimPath, []byte("file a"), 0644)
+
+		efivars := MockEFIVariables{}
+		dp, err := efivars.NewFileDevicePath(shimPath, efi_linux.ShortFormPathHD)
+		if err != nil {
+			t.Fatalf("unable to create shim device path: %v", err)
+		}
+		var latestKernelEntry *BootEntry
+		for bootNum, version := range tt.kernelVersionMap {
+			kernelName := fmt.Sprintf("kernel.efi-%s", version)
+			entry := NewKernelBootEntry("Ubuntu", kernelName, "")
+
+			bootEntryVariable, err := NewBootEntryVariable(entry, bootNum, dp)
+			if err != nil {
+				t.Fatalf("unable to create boot entry variable for %s: %v", kernelName, err)
+			}
+			if version == tt.latestKernelVersion {
+				latestKernelEntry = &entry
+			}
+			mockEntries[bootNum] = bootEntryVariable
+		}
+		bm := BootManager{
+			efivars:     &efivars,
+			entries:     mockEntries,
+			bootCurrent: tt.bootCurrent,
+		}
+
+		bootEntries := []BootEntry{}
+		if latestKernelEntry != nil {
+			bootEntries = []BootEntry{*latestKernelEntry}
+		}
+		km := KernelManager{
+			targetDir:   targetDir,
+			bootEntries: bootEntries,
+			bootManager: &bm,
+		}
+		isCurrentBootLatest, err := km.IsCurrentBootLatest()
+		if err != nil {
+			if !tt.isErr {
+				t.Errorf("%s: unexpected error: %v", testName, err)
+			}
+		}
+		if isCurrentBootLatest != tt.expected {
+			t.Errorf("%s: expected %t, got %t", testName, tt.expected, isCurrentBootLatest)
+		}
+	}
+}

--- a/efibootmgr/kernel_test.go
+++ b/efibootmgr/kernel_test.go
@@ -40,8 +40,18 @@ func TestKernelManagerNewAndInstallKernels(t *testing.T) {
 	appArchitecture = "x64"
 	memFs := afero.NewMemMapFs()
 	appFs = MapFS{memFs}
-	afero.WriteFile(memFs, "/usr/lib/linux/kernel.efi-1.0-12-generic", []byte("1.0-12-generic"), 0644)
-	afero.WriteFile(memFs, "/usr/lib/linux/kernel.efi-1.0-1-generic", []byte("1.0-1-generic"), 0644)
+
+	sourceDir := "/usr/lib/linux/"
+	kernelNames := []string{"kernel.efi-1.0-12-generic", "kernel.efi-1.0-1-generic"}
+	sourceKernels := []Kernel{}
+	for _, kernelName := range kernelNames {
+		k, err := NewKernel(path.Join(sourceDir, kernelName))
+		if err != nil {
+			t.Fatalf("Unable to create Kernel %s: %v", kernelName, err)
+		}
+		sourceKernels = append(sourceKernels, k)
+		afero.WriteFile(memFs, k.FilePath, []byte(kernelName), 0644)
+	}
 	afero.WriteFile(memFs, "/boot/efi/EFI/ubuntu/<dummy>", []byte(""), 0644)
 	afero.WriteFile(memFs, "/etc/kernel/cmdline", []byte("root=magic"), 0644)
 	afero.WriteFile(memFs, "/boot/efi/EFI/ubuntu/shimx64.efi", []byte("file a"), 0644)
@@ -58,15 +68,15 @@ func TestKernelManagerNewAndInstallKernels(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu", &bm)
+	km, err := NewKernelManager("/boot/efi", sourceDir, "ubuntu", &bm)
 	if err != nil {
 		t.Fatalf("Could not create kernel manager: %v", err)
 	}
-	wantSourceKernels := []string{"kernel.efi-1.0-12-generic", "kernel.efi-1.0-1-generic"}
+	wantSourceKernels := sourceKernels
 	if !reflect.DeepEqual(km.sourceKernels, wantSourceKernels) {
 		t.Fatalf("Expected %v, got %v", wantSourceKernels, km.sourceKernels)
 	}
-	var wantTargetKernels []string
+	var wantTargetKernels []Kernel
 	if !reflect.DeepEqual(km.targetKernels, wantTargetKernels) {
 		t.Fatalf("Expected %v, got %v", wantTargetKernels, km.targetKernels)
 	}
@@ -75,10 +85,10 @@ func TestKernelManagerNewAndInstallKernels(t *testing.T) {
 		t.Errorf("Could not install kernels: %v", err)
 	}
 
-	if err := CheckFilesEqual(memFs, "/usr/lib/linux/kernel.efi-1.0-12-generic", "/boot/efi/EFI/ubuntu/kernel.efi-1.0-12-generic"); err != nil {
+	if err := CheckFilesEqual(memFs, sourceKernels[0].FilePath, "/boot/efi/EFI/ubuntu/kernel.efi-1.0-12-generic"); err != nil {
 		t.Error(err)
 	}
-	if err := CheckFilesEqual(memFs, "/usr/lib/linux/kernel.efi-1.0-1-generic", "/boot/efi/EFI/ubuntu/kernel.efi-1.0-1-generic"); err != nil {
+	if err := CheckFilesEqual(memFs, sourceKernels[1].FilePath, "/boot/efi/EFI/ubuntu/kernel.efi-1.0-1-generic"); err != nil {
 		t.Error(err)
 	}
 
@@ -271,7 +281,11 @@ func TestKernelManagerRegisterNewKernelEFIs(t *testing.T) {
 	preGenNum := 2
 	for i := range preGenNum {
 		kernelName := kernelNames[i]
-		entry := NewKernelBootEntry("Ubuntu", kernelName, "")
+		kernel, err := NewKernel(kernelName)
+		if err != nil {
+			t.Fatalf("error creating Kernel type from %s", kernelName)
+		}
+		entry := NewKernelBootEntry("Ubuntu", kernel, "")
 		bm.FindOrCreateEntry(entry, targetDir)
 	}
 
@@ -293,7 +307,10 @@ func TestKernelManagerRegisterNewKernelEFIs(t *testing.T) {
 		t.Errorf("Expected %d entries, got %d", numKernels, numEntries)
 	}
 	for kernelNameIdx, bootNum := range expectedBootNumber {
-		expectedVersionStr := getKernelABI(kernelNames[kernelNameIdx])
+		expectedVersionStr, err := getKernelABI(kernelNames[kernelNameIdx])
+		if err != nil {
+			t.Fatalf("Unable to get kernel ABI from %s: %v", kernelNames[kernelNameIdx], err)
+		}
 		expectedLabel := fmt.Sprintf("Ubuntu with kernel %s", expectedVersionStr)
 		gotDescription := km.bootManager.entries[bootNum].LoadOption.Description
 
@@ -349,7 +366,11 @@ func TestKernelManagerSetLatestKernelToBootNext(t *testing.T) {
 		afero.WriteFile(memFs, kernelTargetPath, []byte(kernelName), 0644)
 
 		// NOTE: create entries this way in the test so boot number can be controlled
-		entry := NewKernelBootEntry("Ubuntu", kernelName, "")
+		kernel, err := NewKernel(kernelName)
+		if err != nil {
+			t.Fatalf("error creating Kernel type from %s", kernelName)
+		}
+		entry := NewKernelBootEntry("Ubuntu", kernel, "")
 		bootEntryVariable, err := NewBootEntryVariable(entry, bootNumber, dp)
 		if err != nil {
 			t.Fatalf("unable to create boot entry variable for %s: %v", kernelName, err)
@@ -439,17 +460,21 @@ func TestKernelManagerIsCurrentBootLatest(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to create shim device path: %v", err)
 		}
-		var latestKernelEntry *BootEntry
+		var latestKernelEntry *KernelEntry
 		for bootNum, version := range tt.kernelVersionMap {
 			kernelName := fmt.Sprintf("kernel.efi-%s", version)
-			entry := NewKernelBootEntry("Ubuntu", kernelName, "")
+			kernel, err := NewKernel(kernelName)
+			if err != nil {
+				t.Fatalf("error creating Kernel type from %s", kernelName)
+			}
+			entry := NewKernelBootEntry("Ubuntu", kernel, "")
 
 			bootEntryVariable, err := NewBootEntryVariable(entry, bootNum, dp)
 			if err != nil {
 				t.Fatalf("unable to create boot entry variable for %s: %v", kernelName, err)
 			}
 			if version == tt.latestKernelVersion {
-				latestKernelEntry = &entry
+				latestKernelEntry = &KernelEntry{kernel, entry}
 			}
 			mockEntries[bootNum] = bootEntryVariable
 		}
@@ -459,14 +484,14 @@ func TestKernelManagerIsCurrentBootLatest(t *testing.T) {
 			bootCurrent: tt.bootCurrent,
 		}
 
-		bootEntries := []BootEntry{}
+		kernelEntries := []KernelEntry{}
 		if latestKernelEntry != nil {
-			bootEntries = []BootEntry{*latestKernelEntry}
+			kernelEntries = []KernelEntry{*latestKernelEntry}
 		}
 		km := KernelManager{
-			targetDir:   targetDir,
-			bootEntries: bootEntries,
-			bootManager: &bm,
+			targetDir:     targetDir,
+			kernelEntries: kernelEntries,
+			bootManager:   &bm,
 		}
 		isCurrentBootLatest, err := km.IsCurrentBootLatest()
 		if err != nil {
@@ -477,5 +502,42 @@ func TestKernelManagerIsCurrentBootLatest(t *testing.T) {
 		if isCurrentBootLatest != tt.expected {
 			t.Errorf("%s: expected %t, got %t", testName, tt.expected, isCurrentBootLatest)
 		}
+	}
+}
+
+func TestKernelManagerGetLatestKernelEntry(t *testing.T) {
+	expectedLatestKPath := "kernel.efi-100"
+	kernelPaths := []string{"kernel.efi-1", "kernel.efi-20", expectedLatestKPath, "kernel.efi-2"}
+	kernelEntries := []KernelEntry{}
+
+	genTestKernelEntry := func(k Kernel) BootEntry {
+		return NewKernelBootEntry("Ubuntu", k, "")
+	}
+	for _, kPath := range kernelPaths {
+		k, err := NewKernel(kPath)
+		if err != nil {
+			t.Fatalf("Failed to create kernel %s: %v", kPath, err)
+		}
+		entry := genTestKernelEntry(k)
+		kEntry := KernelEntry{k, entry}
+		kernelEntries = append(kernelEntries, kEntry)
+	}
+
+	expectedLatestK, err := NewKernel(expectedLatestKPath)
+	expectedLatestEntry := genTestKernelEntry(expectedLatestK)
+	expectedLatestKEntry := KernelEntry{expectedLatestK, expectedLatestEntry}
+
+	if err != nil {
+		t.Fatalf("Failed to create kernel %s: %v", expectedLatestKPath, err)
+	}
+
+	km := KernelManager{kernelEntries: kernelEntries}
+	latest, err := km.GetLatestKernelEntry()
+	if err != nil {
+		t.Fatalf("Failed to get latest kernel: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedLatestKEntry, latest) {
+		t.Errorf("Expected latest kernel %s, got %s", expectedLatestKPath, latest.kernel.FilePath)
 	}
 }

--- a/efibootmgr/kernel_test.go
+++ b/efibootmgr/kernel_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"path"
 	"reflect"
 	"strings"
 	"testing"
@@ -80,6 +81,10 @@ func TestKernelManagerNewAndInstallKernels(t *testing.T) {
 		t.Error(err)
 	}
 
+	if err := km.RegisterNewKernelEFIs(); err != nil {
+		t.Errorf("could not register new Kernels as EFIs: %v", err)
+	}
+
 	if err := km.CommitToBootLoader(); err != nil {
 		t.Errorf("Could not commit to bootloader: %v", err)
 	}
@@ -142,6 +147,10 @@ func TestKernelManager_noCmdLine(t *testing.T) {
 	km, err := NewKernelManager("/boot/efi", "/usr/lib/linux", "ubuntu", &bm)
 	if err := km.InstallKernels(); err != nil {
 		t.Errorf("Could not install kernels: %v", err)
+	}
+
+	if err := km.RegisterNewKernelEFIs(); err != nil {
+		t.Errorf("could not register new Kernels as EFIs: %v", err)
 	}
 
 	if err := km.CommitToBootLoader(); err != nil {
@@ -218,6 +227,82 @@ func TestKernelManagerRemoveObsoleteKernels(t *testing.T) {
 
 	if km.targetKernels != nil {
 		t.Errorf("expected list of target kernels to be empty now, got: %v", km.targetKernels)
+	}
+
+}
+
+func TestKernelManagerRegisterNewKernelEFIs(t *testing.T) {
+	appArchitecture = "x64"
+	memFs := afero.NewMemMapFs()
+	appFs = MapFS{memFs}
+
+	esp := "/boot/efi"
+	targetDir := "/boot/efi/EFI/ubuntu"
+	sourceDir := "/usr/lib/linux"
+
+	// Generate fake kernel files
+	kernelNames := []string{
+		"kernel.efi-1",
+		"kernel.efi-2",
+		"kernel.efi-6",
+		"kernel.efi-3",
+		"kernel.efi-5",
+	}
+	// Maps kernelNames idx to expected bootNum
+	expectedBootNumber := []int{4, 3, 0, 2, 1}
+	for _, kernelName := range kernelNames {
+		kernelSourcePath := path.Join(sourceDir, kernelName)
+		kernelTargetPath := path.Join(targetDir, kernelName)
+		afero.WriteFile(memFs, kernelSourcePath, []byte(kernelName), 0644)
+		afero.WriteFile(memFs, kernelTargetPath, []byte(kernelName), 0644)
+	}
+
+	efivars := MockEFIVariables{}
+	bm, err := NewBootManagerForVariables(&efivars)
+	if err != nil {
+		t.Fatalf("unable to create BootManager: %v", err)
+	}
+
+	// Pre-generate a couple of EFI variables to test RegisterNewKernelEFIs
+	// does not duplicate any of them so we create Boot0000 and Boot0001
+	// associated to kernel.efi-1 and kernel.efi-2 to ensure only one of
+	// each exist at the end
+	preGenNum := 2
+	for i := range preGenNum {
+		kernelName := kernelNames[i]
+		entry := NewKernelBootEntry("Ubuntu", kernelName, "")
+		bm.FindOrCreateEntry(entry, targetDir)
+	}
+
+	shimPath := path.Join(targetDir, "shimx64.efi")
+	afero.WriteFile(memFs, shimPath, []byte("file a"), 0644)
+
+	km, err := NewKernelManager(esp, sourceDir, "ubuntu", &bm)
+	if err != nil {
+		t.Fatalf("unable to create KernelManager: %v", err)
+	}
+	if err := km.InstallKernels(); err != nil {
+		t.Fatalf("unable to install kernels: %v", err)
+	}
+
+	km.RegisterNewKernelEFIs()
+	numEntries := len(km.bootManager.entries)
+	numKernels := len(kernelNames)
+	if numEntries != numKernels {
+		t.Errorf("Expected %d entries, got %d", numKernels, numEntries)
+	}
+	for kernelNameIdx, bootNum := range expectedBootNumber {
+		expectedVersionStr := getKernelABI(kernelNames[kernelNameIdx])
+		expectedLabel := fmt.Sprintf("Ubuntu with kernel %s", expectedVersionStr)
+		gotDescription := km.bootManager.entries[bootNum].LoadOption.Description
+
+		// The "real" comparison is the BootEntryVariable.Data however, the
+		// only difference between each variable is the Description field
+		// and encoding the loadOption requires much more setup since it
+		// requires a BootManager with efivars to create the DevicePath
+		if gotDescription != expectedLabel {
+			t.Errorf("Expected %s, got %s", expectedLabel, gotDescription)
+		}
 	}
 
 }

--- a/efibootmgr/kernel_test.go
+++ b/efibootmgr/kernel_test.go
@@ -251,6 +251,21 @@ func TestKernelManagerRegisterNewKernelEFIs(t *testing.T) {
 	targetDir := "/boot/efi/EFI/ubuntu"
 	sourceDir := "/usr/lib/linux"
 
+	// Shim file is needed to create BootEntryVariable's since it is the
+	// DevicePath value for all of them
+	shimPath := path.Join(targetDir, "shimx64.efi")
+	afero.WriteFile(memFs, shimPath, []byte("file a"), 0644)
+
+	efivars := MockEFIVariables{}
+	bm, err := NewBootManagerForVariables(&efivars)
+	if err != nil {
+		t.Fatalf("unable to create BootManager: %v", err)
+	}
+	shimDp, err := bm.efivars.NewFileDevicePath(shimPath, efi_linux.ShortFormPathHD)
+	if err != nil {
+		t.Fatalf("unable to create DevicePath for %s: %v", shimPath, err)
+	}
+
 	// Generate fake kernel files
 	kernelNames := []string{
 		"kernel.efi-1",
@@ -259,25 +274,10 @@ func TestKernelManagerRegisterNewKernelEFIs(t *testing.T) {
 		"kernel.efi-3",
 		"kernel.efi-5",
 	}
-	// Maps kernelNames idx to expected bootNum
-	expectedBootNumber := []int{4, 3, 0, 2, 1}
-	for _, kernelName := range kernelNames {
-		kernelSourcePath := path.Join(sourceDir, kernelName)
-		kernelTargetPath := path.Join(targetDir, kernelName)
-		afero.WriteFile(memFs, kernelSourcePath, []byte(kernelName), 0644)
-		afero.WriteFile(memFs, kernelTargetPath, []byte(kernelName), 0644)
-	}
-
-	efivars := MockEFIVariables{}
-	bm, err := NewBootManagerForVariables(&efivars)
-	if err != nil {
-		t.Fatalf("unable to create BootManager: %v", err)
-	}
-
 	// Pre-generate a couple of EFI variables to test RegisterNewKernelEFIs
-	// does not duplicate any of them so we create Boot0000 and Boot0001
-	// associated to kernel.efi-1 and kernel.efi-2 to ensure only one of
-	// each exist at the end
+	// does not duplicate any entries. This creates Boot0000 and Boot0001
+	// associated to kernel.efi-1 and kernel.efi-2. Then we ensure only one
+	// of each of them exist at the end
 	preGenNum := 2
 	for i := range preGenNum {
 		kernelName := kernelNames[i]
@@ -286,11 +286,39 @@ func TestKernelManagerRegisterNewKernelEFIs(t *testing.T) {
 			t.Fatalf("error creating Kernel type from %s", kernelName)
 		}
 		entry := NewKernelBootEntry("Ubuntu", kernel, "")
-		bm.FindOrCreateEntry(entry, targetDir)
+		_, err = bm.FindOrCreateEntry(entry, targetDir)
+		if err != nil {
+			t.Fatalf("error creating kernel EFI Boot Variable for %s: %v", entry.Label, err)
+		}
 	}
+	// This maps each kernelName to an expected boot number by index
+	// Rationale:
+	// 0, 1: they are generated before NewKernelManager is executed
+	// 2, 4, 3: Version ordered from NewKernelManager
+	// kernel.efi-6 -> (2), kernel.efi-5 -> (3), kernel.efi-3 -> (4)
+	expectedBootNumber := []int{0, 1, 2, 4, 3}
 
-	shimPath := path.Join(targetDir, "shimx64.efi")
-	afero.WriteFile(memFs, shimPath, []byte("file a"), 0644)
+	// Maps kernelNames idx to expected bootNum
+	for _, kernelName := range kernelNames {
+		kernelSourcePath := path.Join(sourceDir, kernelName)
+		kernelTargetPath := path.Join(targetDir, kernelName)
+		afero.WriteFile(memFs, kernelSourcePath, []byte(kernelName), 0644)
+		afero.WriteFile(memFs, kernelTargetPath, []byte(kernelName), 0644)
+	}
+	expectedBootEntryVariables := []BootEntryVariable{}
+	for kNameIdx, bootNumber := range expectedBootNumber {
+		kName := kernelNames[kNameIdx]
+		k, err := NewKernel(kName)
+		if err != nil {
+			t.Fatalf("unable to create kernel for %s: %v", kName, err)
+		}
+		kEntry := NewKernelBootEntry("Ubuntu", k, "")
+		kEntryVar, err := NewBootEntryVariable(kEntry, bootNumber, shimDp)
+		if err != nil {
+			t.Fatalf("unable to create BootEntryVariable for %s: %v", kName, err)
+		}
+		expectedBootEntryVariables = append(expectedBootEntryVariables, kEntryVar)
+	}
 
 	km, err := NewKernelManager(esp, sourceDir, "ubuntu", &bm)
 	if err != nil {
@@ -306,20 +334,10 @@ func TestKernelManagerRegisterNewKernelEFIs(t *testing.T) {
 	if numEntries != numKernels {
 		t.Errorf("Expected %d entries, got %d", numKernels, numEntries)
 	}
-	for kernelNameIdx, bootNum := range expectedBootNumber {
-		expectedVersionStr, err := getKernelABI(kernelNames[kernelNameIdx])
-		if err != nil {
-			t.Fatalf("Unable to get kernel ABI from %s: %v", kernelNames[kernelNameIdx], err)
-		}
-		expectedLabel := fmt.Sprintf("Ubuntu with kernel %s", expectedVersionStr)
-		gotDescription := km.bootManager.entries[bootNum].LoadOption.Description
-
-		// The "real" comparison is the BootEntryVariable.Data however, the
-		// only difference between each variable is the Description field
-		// and encoding the loadOption requires much more setup since it
-		// requires a BootManager with efivars to create the DevicePath
-		if gotDescription != expectedLabel {
-			t.Errorf("Expected %s, got %s", expectedLabel, gotDescription)
+	for _, entryVar := range expectedBootEntryVariables {
+		gotEntryVar := km.bootManager.entries[entryVar.BootNumber]
+		if !reflect.DeepEqual(gotEntryVar, entryVar) {
+			t.Errorf("Expected %s, got %s", entryVar.LoadOption.Description, gotEntryVar.LoadOption.Description)
 		}
 	}
 

--- a/efibootmgr/reseal.go
+++ b/efibootmgr/reseal.go
@@ -243,17 +243,26 @@ func ResealKey(assets *TrustedAssets, km *KernelManager, esp, shimSource, vendor
 
 	var kernels []*secboot_efi.ImageLoadEvent
 
+	sourceKernelNames := []string{}
+	for _, sk := range km.sourceKernels {
+		sourceKernelNames = append(sourceKernelNames, sk.GetKernelName())
+	}
+	targetKernelNames := []string{}
+	for _, tk := range km.targetKernels {
+		targetKernelNames = append(targetKernelNames, tk.GetKernelName())
+	}
+
 	for _, x := range []struct {
 		dir   string
 		files []string
 	}{
 		{
 			dir:   km.sourceDir,
-			files: km.sourceKernels,
+			files: sourceKernelNames,
 		},
 		{
 			dir:   km.targetDir,
-			files: km.targetKernels,
+			files: targetKernelNames,
 		},
 	} {
 		for _, n := range x.files {

--- a/efibootmgr/shim.go
+++ b/efibootmgr/shim.go
@@ -23,6 +23,23 @@ type BootEntry struct {
 	Description string
 }
 
+func NewKernelBootEntry(vendor string, kernelName string, kernelOptions string) BootEntry {
+	version := getKernelABI(kernelName)
+	// It is worth pointing out that the argument for shim should start with \
+	// which here somehow denotes it is in the same directory rather than the root.
+	// FIXME: Extract vendor name out into config file
+	options := "\\" + kernelName
+	if kernelOptions != "" {
+		options += " " + kernelOptions
+	}
+	return BootEntry{
+		Filename:    "shim" + GetEfiArchitecture() + ".efi",
+		Label:       fmt.Sprintf("%s with kernel %s", vendor, version),
+		Options:     options,
+		Description: fmt.Sprintf("%s entry for kernel %s", vendor, version),
+	}
+}
+
 // architectureMaps maps from GOARCH to host
 var architectureMap = map[string]string{
 	"386":      "ia32",

--- a/efibootmgr/shim.go
+++ b/efibootmgr/shim.go
@@ -23,20 +23,20 @@ type BootEntry struct {
 	Description string
 }
 
-func NewKernelBootEntry(vendor string, kernelName string, kernelOptions string) BootEntry {
-	version := getKernelABI(kernelName)
+func NewKernelBootEntry(vendor string, kernel Kernel, kernelOptions string) BootEntry {
 	// It is worth pointing out that the argument for shim should start with \
 	// which here somehow denotes it is in the same directory rather than the root.
 	// FIXME: Extract vendor name out into config file
-	options := "\\" + kernelName
+	options := "\\" + kernel.GetKernelName()
 	if kernelOptions != "" {
 		options += " " + kernelOptions
 	}
+	versionStr := kernel.Version.String()
 	return BootEntry{
 		Filename:    "shim" + GetEfiArchitecture() + ".efi",
-		Label:       fmt.Sprintf("%s with kernel %s", vendor, version),
+		Label:       fmt.Sprintf("%s with kernel %s", vendor, versionStr),
 		Options:     options,
-		Description: fmt.Sprintf("%s entry for kernel %s", vendor, version),
+		Description: fmt.Sprintf("%s entry for kernel %s", vendor, versionStr),
 	}
 }
 


### PR DESCRIPTION
Added a kernel fallback mechanism for new kernel installations such that new kernels boot via BootNext instead of being the first entry in the persistent BootOrder. BootNext is used and then automatically deleted by UEFI upon each boot, meaning that if BootNext fails to boot, the bootloader will fallback to the BootOrder, and resume normal operations. Tested with the unit tests in the repository as well as the tests pending acceptance in ubuntu-boot-test (see https://warthogs.atlassian.net/browse/CPC-9074 for more information)