### PR TITLE
feat: Systemd one-shot service for Kernel fallback mechanism

### DIFF
--- a/debian/nullboot-fallback.service
+++ b/debian/nullboot-fallback.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Ammend boot loader on successful kernel upgrades for TPM-backed FDE instances
+
+# Runs after basic system initialization and local filesystems are mounted.
+# This ensures a stable environment before proceeding to higher-level services.
+After=sysinit.target local-fs.target
+
+[Service]
+Type=oneshot
+
+# If BootCurrent is the latest kernel, update BootOrder
+# Also ensures a bad kernel is not reset to BootNext if a boot was unsuccessful
+ExecStart=/usr/bin/nullbootctl -no-boot-next
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/nullboot.postinst
+++ b/debian/nullboot.postinst
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -e
-if [ "$1" = "triggered" ] || [ "$1" = "configure" ]; then
-    if [ -e "/boot/efi/EFI/ubuntu/" ]; then
-        nullbootctl
-    fi
+if [ "$1" = "configure" ] && [ -e "/boot/efi/EFI/ubuntu/" ]; then
+    systemctl enable nullboot-fallback.service
+    nullbootctl
+fi
+if [ "$1" = "triggered" ] && [ -e "/boot/efi/EFI/ubuntu/" ]; then
+    nullbootctl
 fi
 
 #DEBHELPER#

--- a/debian/rules
+++ b/debian/rules
@@ -27,6 +27,9 @@ override_dh_gencontrol:
 	dh_gencontrol -- -Vshim-signed:Version=$(SHIM_SIGNED_VERSION)
 
 override_dh_auto_install:
+	mkdir -p debian/nullboot/etc/systemd/system
+	cp debian/nullboot-fallback.service debian/nullboot/etc/systemd/system/
+	chmod +x debian/nullboot/etc/systemd/system/nullboot-fallback.service
 	mkdir -p debian/nullboot/usr/lib/nullboot/shim
 	cp $(SHIM_DIR)/shim*.signed $(SHIM_DIR)/fb*.efi $(SHIM_DIR)/mm*.efi debian/nullboot/usr/lib/nullboot/shim
 	dh_auto_install -- --no-source


### PR DESCRIPTION
Adds a systemd one-shot service to amend the bootloader on a successfully booted, new kernel entry using the -no-boot-next option.

Should a newly installed kernel panic while booting, no changes will occur in the boot loader and the service ensures BootNext is not set again on the bad kernel (unless another evocation of nullbootctl does).

In the event that a new kernel successfully boots, nullboot will amend the boot loader with the new kernel.

This is the first systemd service I've written, so feel free to nit pick anything. I did test that this works with my changes to ubuntu-boot-test.


Also note: we cannot merge this until the changes from https://github.com/canonical/nullboot/pull/144 reach the `ubuntu/main` branch since it requires the `no-boot-next` flag and the new fallback-mechanism to be enabled.