### PR TITLE
Pin goroutine to OS thread when reading the primary key

### DIFF
--- a/efibootmgr/reseal.go
+++ b/efibootmgr/reseal.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -114,6 +115,16 @@ func getPrimaryKeyFromKernel() (secboot.PrimaryKey, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot resolve devive symlink: %w", err)
 	}
+
+	// The keyring is stored in OS thread (task_struct in linux kernel), not the process
+	// Link a keyring into it only takes effect for whichever thread performs the link
+	// and Go is free to reschedule this goroutine onto a different OS thread between
+	// syscalls.
+	// Pin the goroutine to its current thread, so both KEYCTL_LINK and the key read are
+	// able to access the same keyring; otherwise the read intermittently fails with
+	// permission denied, because it's on a thread whose keyring never got the link.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	// By default, system services get their own session keyring that doesn't have
 	// the user keyring linked to it. This means that attempting to read a key from


### PR DESCRIPTION
The keyring links established by KEYCTL_LINK are per-thread, but Go may reschedule the goroutine onto a different OS thread between the link and the subsequent key read, making the read intermittently fail with permission denied:
final reseal failed: cannot obtain auth key from kernel: cannot read key from kernel: cannot determine size of key payload: permission denied

Wrap the link and read in runtime.LockOSThread()/UnlockOSThread() so both syscalls run on the same thread.